### PR TITLE
Delivery for clang-formatter integration

### DIFF
--- a/.clang-format
+++ b/.clang-format
@@ -1,0 +1,280 @@
+﻿---
+Language:        Cpp
+# BasedOnStyle:  Google
+AccessModifierOffset: -3
+AlignAfterOpenBracket: Align
+AlignArrayOfStructures: None
+AlignConsecutiveAssignments:
+  Enabled:         false
+  AcrossEmptyLines: false
+  AcrossComments:  false
+  AlignCompound:   false
+  AlignFunctionPointers: false
+  PadOperators:    true
+AlignConsecutiveBitFields:
+  Enabled:         false
+  AcrossEmptyLines: false
+  AcrossComments:  false
+  AlignCompound:   false
+  AlignFunctionPointers: false
+  PadOperators:    false
+AlignConsecutiveDeclarations:
+  Enabled:         false
+  AcrossEmptyLines: false
+  AcrossComments:  false
+  AlignCompound:   false
+  AlignFunctionPointers: false
+  PadOperators:    false
+AlignConsecutiveMacros:
+  Enabled:         false
+  AcrossEmptyLines: false
+  AcrossComments:  false
+  AlignCompound:   false
+  AlignFunctionPointers: false
+  PadOperators:    false
+AlignConsecutiveShortCaseStatements:
+  Enabled:         false
+  AcrossEmptyLines: false
+  AcrossComments:  false
+  AlignCaseColons: false
+AlignEscapedNewlines: Left
+AlignOperands:   Align
+AlignTrailingComments:
+  Kind:            Always
+  OverEmptyLines:  0
+AllowAllArgumentsOnNextLine: true
+AllowAllParametersOfDeclarationOnNextLine: true
+AllowBreakBeforeNoexceptSpecifier: Never
+AllowShortBlocksOnASingleLine: Never
+AllowShortCaseLabelsOnASingleLine: false
+AllowShortCompoundRequirementOnASingleLine: true
+AllowShortEnumsOnASingleLine: true
+AllowShortFunctionsOnASingleLine: All
+AllowShortIfStatementsOnASingleLine: WithoutElse
+AllowShortLambdasOnASingleLine: All
+AllowShortLoopsOnASingleLine: true
+AlwaysBreakAfterDefinitionReturnType: None
+AlwaysBreakAfterReturnType: None
+AlwaysBreakBeforeMultilineStrings: true
+AlwaysBreakTemplateDeclarations: Yes
+AttributeMacros:
+  - __capability
+BinPackArguments: true
+BinPackParameters: true
+BitFieldColonSpacing: Both
+BraceWrapping:
+  AfterCaseLabel:  true
+  AfterClass:      true
+  AfterControlStatement: Never
+  AfterEnum:       true
+  AfterExternBlock: true
+  AfterFunction:   true
+  AfterNamespace:  true
+  AfterObjCDeclaration: false
+  AfterStruct:     true
+  AfterUnion:      true
+  BeforeCatch:     true
+  BeforeElse:      true
+  BeforeLambdaBody: false
+  BeforeWhile:     false
+  IndentBraces:    true
+  SplitEmptyFunction: true
+  SplitEmptyRecord: true
+  SplitEmptyNamespace: true
+BreakAdjacentStringLiterals: true
+BreakAfterAttributes: Leave
+BreakAfterJavaFieldAnnotations: false
+BreakArrays:     true
+BreakBeforeBinaryOperators: None
+BreakBeforeConceptDeclarations: Always
+BreakBeforeBraces: Custom
+BreakBeforeInlineASMColon: OnlyMultiline
+BreakBeforeTernaryOperators: true
+BreakConstructorInitializers: BeforeColon
+BreakInheritanceList: BeforeColon
+BreakStringLiterals: true
+ColumnLimit:     80
+CommentPragmas:  '^ IWYU pragma:'
+CompactNamespaces: false
+ConstructorInitializerIndentWidth: 3
+ContinuationIndentWidth: 3
+Cpp11BracedListStyle: true
+DerivePointerAlignment: true
+DisableFormat:   false
+EmptyLineAfterAccessModifier: Never
+EmptyLineBeforeAccessModifier: LogicalBlock
+ExperimentalAutoDetectBinPacking: false
+FixNamespaceComments: true
+ForEachMacros:
+  - foreach
+  - Q_FOREACH
+  - BOOST_FOREACH
+IfMacros:
+  - KJ_IF_MAYBE
+IncludeBlocks:   Regroup
+IncludeCategories:
+  - Regex:           '^<ext/.*\.h>'
+    Priority:        2
+    SortPriority:    0
+    CaseSensitive:   false
+  - Regex:           '^<.*\.h>'
+    Priority:        1
+    SortPriority:    0
+    CaseSensitive:   false
+  - Regex:           '^<.*'
+    Priority:        2
+    SortPriority:    0
+    CaseSensitive:   false
+  - Regex:           '.*'
+    Priority:        3
+    SortPriority:    0
+    CaseSensitive:   false
+IncludeIsMainRegex: '([-_](test|unittest))?$'
+IncludeIsMainSourceRegex: ''
+IndentAccessModifiers: false
+IndentCaseBlocks: false
+IndentCaseLabels: true
+IndentExternBlock: AfterExternBlock
+IndentGotoLabels: true
+IndentPPDirectives: None
+IndentRequiresClause: true
+IndentWidth:     3
+IndentWrappedFunctionNames: false
+InsertBraces:    false
+InsertNewlineAtEOF: false
+InsertTrailingCommas: None
+IntegerLiteralSeparator:
+  Binary:          0
+  BinaryMinDigits: 0
+  Decimal:         0
+  DecimalMinDigits: 0
+  Hex:             0
+  HexMinDigits:    0
+JavaScriptQuotes: Leave
+JavaScriptWrapImports: true
+KeepEmptyLinesAtTheStartOfBlocks: false
+KeepEmptyLinesAtEOF: false
+LambdaBodyIndentation: Signature
+LineEnding:      DeriveLF
+MacroBlockBegin: ''
+MacroBlockEnd:   ''
+MaxEmptyLinesToKeep: 1
+NamespaceIndentation: None
+ObjCBinPackProtocolList: Never
+ObjCBlockIndentWidth: 3
+ObjCBreakBeforeNestedBlockParam: true
+ObjCSpaceAfterProperty: false
+ObjCSpaceBeforeProtocolList: true
+PackConstructorInitializers: NextLine
+PenaltyBreakAssignment: 2
+PenaltyBreakBeforeFirstCallParameter: 1
+PenaltyBreakComment: 300
+PenaltyBreakFirstLessLess: 120
+PenaltyBreakOpenParenthesis: 0
+PenaltyBreakScopeResolution: 500
+PenaltyBreakString: 1000
+PenaltyBreakTemplateDeclaration: 10
+PenaltyExcessCharacter: 1000000
+PenaltyIndentedWhitespace: 0
+PenaltyReturnTypeOnItsOwnLine: 200
+PointerAlignment: Left
+PPIndentWidth:   -1
+QualifierAlignment: Leave
+RawStringFormats:
+  - Language:        Cpp
+    Delimiters:
+      - cc
+      - CC
+      - cpp
+      - Cpp
+      - CPP
+      - 'c++'
+      - 'C++'
+    CanonicalDelimiter: ''
+    BasedOnStyle:    google
+  - Language:        TextProto
+    Delimiters:
+      - pb
+      - PB
+      - proto
+      - PROTO
+    EnclosingFunctions:
+      - EqualsProto
+      - EquivToProto
+      - PARSE_PARTIAL_TEXT_PROTO
+      - PARSE_TEST_PROTO
+      - PARSE_TEXT_PROTO
+      - ParseTextOrDie
+      - ParseTextProtoOrDie
+      - ParseTestProto
+      - ParsePartialTestProto
+    CanonicalDelimiter: pb
+    BasedOnStyle:    google
+ReferenceAlignment: Pointer
+ReflowComments:  true
+RemoveBracesLLVM: false
+RemoveParentheses: Leave
+RemoveSemicolon: false
+RequiresClausePosition: OwnLine
+RequiresExpressionIndentation: OuterScope
+SeparateDefinitionBlocks: Leave
+ShortNamespaceLines: 1
+SkipMacroDefinitionBody: false
+SortIncludes:    CaseSensitive
+SortJavaStaticImport: Before
+SortUsingDeclarations: LexicographicNumeric
+SpaceAfterCStyleCast: false
+SpaceAfterLogicalNot: false
+SpaceAfterTemplateKeyword: true
+SpaceAroundPointerQualifiers: Default
+SpaceBeforeAssignmentOperators: true
+SpaceBeforeCaseColon: false
+SpaceBeforeCpp11BracedList: false
+SpaceBeforeCtorInitializerColon: true
+SpaceBeforeInheritanceColon: true
+SpaceBeforeJsonColon: false
+SpaceBeforeParens: ControlStatements
+SpaceBeforeParensOptions:
+  AfterControlStatements: true
+  AfterForeachMacros: true
+  AfterFunctionDefinitionName: false
+  AfterFunctionDeclarationName: false
+  AfterIfMacros:   true
+  AfterOverloadedOperator: false
+  AfterPlacementOperator: true
+  AfterRequiresInClause: false
+  AfterRequiresInExpression: false
+  BeforeNonEmptyParentheses: false
+SpaceBeforeRangeBasedForLoopColon: true
+SpaceBeforeSquareBrackets: false
+SpaceInEmptyBlock: false
+SpacesBeforeTrailingComments: 2
+SpacesInAngles:  Never
+SpacesInContainerLiterals: true
+SpacesInLineCommentPrefix:
+  Minimum:         1
+  Maximum:         -1
+SpacesInParens:  Never
+SpacesInParensOptions:
+  InCStyleCasts:   false
+  InConditionalStatements: false
+  InEmptyParentheses: false
+  Other:           false
+SpacesInSquareBrackets: false
+Standard:        Auto
+StatementAttributeLikeMacros:
+  - Q_EMIT
+StatementMacros:
+  - Q_UNUSED
+  - QT_REQUIRE_VERSION
+TabWidth:        8
+UseTab:          Never
+VerilogBreakBetweenInstancePorts: true
+WhitespaceSensitiveMacros:
+  - BOOST_PP_STRINGIZE
+  - CF_SWIFT_NAME
+  - NS_SWIFT_NAME
+  - PP_STRINGIZE
+  - STRINGIZE
+...
+

--- a/.clang-format
+++ b/.clang-format
@@ -5,7 +5,7 @@ AccessModifierOffset: -3
 AlignAfterOpenBracket: Align
 AlignArrayOfStructures: None
 AlignConsecutiveAssignments:
-  Enabled:         false
+  Enabled:         true
   AcrossEmptyLines: false
   AcrossComments:  false
   AlignCompound:   false
@@ -65,7 +65,7 @@ BitFieldColonSpacing: Both
 BraceWrapping:
   AfterCaseLabel:  true
   AfterClass:      true
-  AfterControlStatement: Never
+  AfterControlStatement: Always
   AfterEnum:       true
   AfterExternBlock: true
   AfterFunction:   true
@@ -77,7 +77,7 @@ BraceWrapping:
   BeforeElse:      true
   BeforeLambdaBody: false
   BeforeWhile:     false
-  IndentBraces:    true
+  IndentBraces:    false
   SplitEmptyFunction: true
   SplitEmptyRecord: true
   SplitEmptyNamespace: true
@@ -90,7 +90,7 @@ BreakBeforeConceptDeclarations: Always
 BreakBeforeBraces: Custom
 BreakBeforeInlineASMColon: OnlyMultiline
 BreakBeforeTernaryOperators: true
-BreakConstructorInitializers: BeforeColon
+BreakConstructorInitializers: BeforeComma
 BreakInheritanceList: BeforeColon
 BreakStringLiterals: true
 ColumnLimit:     80
@@ -98,7 +98,7 @@ CommentPragmas:  '^ IWYU pragma:'
 CompactNamespaces: false
 ConstructorInitializerIndentWidth: 3
 ContinuationIndentWidth: 3
-Cpp11BracedListStyle: true
+Cpp11BracedListStyle: false
 DerivePointerAlignment: true
 DisableFormat:   false
 EmptyLineAfterAccessModifier: Never
@@ -118,7 +118,7 @@ IncludeCategories:
     SortPriority:    0
     CaseSensitive:   false
   - Regex:           '^<.*\.h>'
-    Priority:        1
+    Priority:        3
     SortPriority:    0
     CaseSensitive:   false
   - Regex:           '^<.*'
@@ -126,7 +126,7 @@ IncludeCategories:
     SortPriority:    0
     CaseSensitive:   false
   - Regex:           '.*'
-    Priority:        3
+    Priority:        1
     SortPriority:    0
     CaseSensitive:   false
 IncludeIsMainRegex: '([-_](test|unittest))?$'
@@ -165,7 +165,7 @@ ObjCBlockIndentWidth: 3
 ObjCBreakBeforeNestedBlockParam: true
 ObjCSpaceAfterProperty: false
 ObjCSpaceBeforeProtocolList: true
-PackConstructorInitializers: NextLine
+PackConstructorInitializers: Never
 PenaltyBreakAssignment: 2
 PenaltyBreakBeforeFirstCallParameter: 1
 PenaltyBreakComment: 300

--- a/README.md
+++ b/README.md
@@ -2,8 +2,8 @@ Data Structure APIs
 ====================================================================================================
 
 This repo contains below Data Structure APIs in C++.
-* ~~List without iterator - Implemented and Unit Tested.~~
-* **List with iterator - In progress.**
-* Stack - Upcoming
+* ~~List - Implemented and Unit Tested.~~
+  * ~~Iterator - Implemented and Unit Tested.~~
+* **Stack - In Progress**
 * Queue - Upcoming
 * Binary Search Tree - Upcoming

--- a/include/milky_way/list/list.h
+++ b/include/milky_way/list/list.h
@@ -27,14 +27,15 @@ class List
 private:
    struct Node
    {
-      Node(T const& rc_element) : m_node_data{std::move(rc_element)}
+      Node(T const& rc_element)
+         : m_node_data{ std::move(rc_element) }
       {
          // Intentionally left empty.
       }
 
       T m_node_data{};
-      Node* mp_next_node{nullptr};
-      Node* mp_prev_node{nullptr};
+      Node* mp_next_node{ nullptr };
+      Node* mp_prev_node{ nullptr };
    };
 
 public:
@@ -252,13 +253,13 @@ public:
       //////////////////////////////////////////////////////////////////////////////////////////////
       /// @brief Defaulted special member fuctions.
       //////////////////////////////////////////////////////////////////////////////////////////////
-      Iterator(Iterator const&) = default;
-      Iterator& operator=(Iterator const&) = default;
-      Iterator(Iterator&&) noexcept = default;
+      Iterator(Iterator const&)                = default;
+      Iterator& operator=(Iterator const&)     = default;
+      Iterator(Iterator&&) noexcept            = default;
       Iterator& operator=(Iterator&&) noexcept = default;
 
    private:
-      List<T>::Node* mp_current_node{nullptr};
+      List<T>::Node* mp_current_node{ nullptr };
    };
 
    /////////////////////////////////////////////////////////////////////////////////////////////////
@@ -297,9 +298,9 @@ private:
 
    void copy_list(List<T> const&);
 
-   Node* mp_head{nullptr};
-   Node* mp_tail{nullptr};
-   size_t m_total_nodes{0U};
+   Node* mp_head{ nullptr };
+   Node* mp_tail{ nullptr };
+   size_t m_total_nodes{ 0U };
 };
 
 ////////////////////////////////////////////////////////////////////////////////////////////////////
@@ -310,9 +311,10 @@ private:
 template <typename T>
 List<T>::List(std::initializer_list<T> const& rc_init_list)
 {
-      for (auto const& element : rc_init_list) {
-         this->push_back(element);
-      }
+   for (auto const& element : rc_init_list)
+   {
+      this->push_back(element);
+   }
 }
 
 ////////////////////////////////////////////////////////////////////////////////////////////////////
@@ -333,9 +335,10 @@ List<T>::List(List<T> const& rhs)
 template <typename T>
 List<T>& List<T>::operator=(List<T> const& rhs)
 {
-      if (this != &rhs) {
-         this->copy_list(rhs);
-      }
+   if (this != &rhs)
+   {
+      this->copy_list(rhs);
+   }
 
    return *this;
 }
@@ -346,12 +349,12 @@ List<T>::List(List<T>&& rhs) noexcept
 {
    this->clear();
 
-   this->mp_head = rhs.mp_head;
-   this->mp_tail = rhs.mp_tail;
+   this->mp_head       = rhs.mp_head;
+   this->mp_tail       = rhs.mp_tail;
    this->m_total_nodes = rhs.m_total_nodes;
 
-   rhs.mp_head = nullptr;
-   rhs.mp_head = nullptr;
+   rhs.mp_head       = nullptr;
+   rhs.mp_head       = nullptr;
    rhs.m_total_nodes = 0U;
 }
 
@@ -359,17 +362,18 @@ List<T>::List(List<T>&& rhs) noexcept
 template <typename T>
 List<T>& List<T>::operator=(List<T>&& rhs) noexcept
 {
-      if (this != &rhs) {
-         this->clear();
+   if (this != &rhs)
+   {
+      this->clear();
 
-         this->mp_head = rhs.mp_head;
-         this->mp_tail = rhs.mp_tail;
-         this->m_total_nodes = rhs.m_total_nodes;
+      this->mp_head       = rhs.mp_head;
+      this->mp_tail       = rhs.mp_tail;
+      this->m_total_nodes = rhs.m_total_nodes;
 
-         rhs.mp_head = nullptr;
-         rhs.mp_head = nullptr;
-         rhs.m_total_nodes = 0U;
-      }
+      rhs.mp_head       = nullptr;
+      rhs.mp_head       = nullptr;
+      rhs.m_total_nodes = 0U;
+   }
 
    return *this;
 }
@@ -378,28 +382,31 @@ List<T>& List<T>::operator=(List<T>&& rhs) noexcept
 template <typename T>
 bool List<T>::operator==(List<T> const& rhs) const
 {
-   auto equality_result{true};
-      if (this != &rhs) {
-            if (this->size() != rhs.size()) {
-               equality_result = false;
-            }
-            else {
-               Node const* lhs_current_node = this->mp_head;
-               Node const* rhs_current_node = rhs.mp_head;
-
-                  while ((lhs_current_node != nullptr) &&
-                         (rhs_current_node != nullptr)) {
-                        if (lhs_current_node->m_node_data !=
-                            rhs_current_node->m_node_data) {
-                           equality_result = false;
-                           break;
-                        }
-
-                     lhs_current_node = lhs_current_node->mp_next_node;
-                     rhs_current_node = rhs_current_node->mp_next_node;
-                  }
-            }
+   auto equality_result{ true };
+   if (this != &rhs)
+   {
+      if (this->size() != rhs.size())
+      {
+         equality_result = false;
       }
+      else
+      {
+         Node const* lhs_current_node = this->mp_head;
+         Node const* rhs_current_node = rhs.mp_head;
+
+         while ((lhs_current_node != nullptr) && (rhs_current_node != nullptr))
+         {
+            if (lhs_current_node->m_node_data != rhs_current_node->m_node_data)
+            {
+               equality_result = false;
+               break;
+            }
+
+            lhs_current_node = lhs_current_node->mp_next_node;
+            rhs_current_node = rhs_current_node->mp_next_node;
+         }
+      }
+   }
 
    return equality_result;
 }
@@ -429,15 +436,17 @@ size_t List<T>::size() const
 template <typename T>
 void List<T>::push_back(T const& rc_element)
 {
-      if (this->is_empty()) {
-         this->mp_head = new Node(rc_element);
-         this->mp_tail = this->mp_head;
-      }
-      else {
-         this->mp_tail->mp_next_node = new Node(rc_element);
-         this->mp_tail->mp_next_node->mp_prev_node = this->mp_tail;
-         this->mp_tail = this->mp_tail->mp_next_node;
-      }
+   if (this->is_empty())
+   {
+      this->mp_head = new Node(rc_element);
+      this->mp_tail = this->mp_head;
+   }
+   else
+   {
+      this->mp_tail->mp_next_node               = new Node(rc_element);
+      this->mp_tail->mp_next_node->mp_prev_node = this->mp_tail;
+      this->mp_tail                             = this->mp_tail->mp_next_node;
+   }
 
    ++this->m_total_nodes;
 
@@ -448,16 +457,18 @@ void List<T>::push_back(T const& rc_element)
 template <typename T>
 void List<T>::push_front(T const& rc_element)
 {
-      if (this->is_empty()) {
-         this->mp_head = new Node(rc_element);
-         this->mp_tail = this->mp_head;
-      }
-      else {
-         Node* temp = new Node(rc_element);
-         temp->mp_next_node = this->mp_head;
-         this->mp_head->mp_prev_node = temp;
-         this->mp_head = this->mp_head->mp_prev_node;
-      }
+   if (this->is_empty())
+   {
+      this->mp_head = new Node(rc_element);
+      this->mp_tail = this->mp_head;
+   }
+   else
+   {
+      Node* temp                  = new Node(rc_element);
+      temp->mp_next_node          = this->mp_head;
+      this->mp_head->mp_prev_node = temp;
+      this->mp_head               = this->mp_head->mp_prev_node;
+   }
 
    ++this->m_total_nodes;
 
@@ -468,18 +479,21 @@ void List<T>::push_front(T const& rc_element)
 template <typename T>
 bool List<T>::find(T const& rc_element) const
 {
-      if (this->is_empty()) {
-         return false;
-      }
+   if (this->is_empty())
+   {
+      return false;
+   }
 
-   bool found{false};
+   bool found{ false };
    Node* current_node = this->mp_head;
-      while (current_node != nullptr) {
-            if (current_node->m_node_data == rc_element) {
-               found = true;
-            }
-         current_node = current_node->mp_next_node;
+   while (current_node != nullptr)
+   {
+      if (current_node->m_node_data == rc_element)
+      {
+         found = true;
       }
+      current_node = current_node->mp_next_node;
+   }
 
    return found;
 }
@@ -516,17 +530,19 @@ T& List<T>::back()
 template <typename T>
 void List<T>::clear()
 {
-      if (this->is_empty()) {
-         return;
-      }
+   if (this->is_empty())
+   {
+      return;
+   }
 
    Node* current_node = this->mp_head;
-      while (current_node != nullptr) {
-         Node* temp_node = current_node;
-         current_node = current_node->mp_next_node;
-         delete temp_node;
-         --this->m_total_nodes;
-      }
+   while (current_node != nullptr)
+   {
+      Node* temp_node = current_node;
+      current_node    = current_node->mp_next_node;
+      delete temp_node;
+      --this->m_total_nodes;
+   }
 
    this->mp_head = nullptr;
    this->mp_tail = nullptr;
@@ -538,25 +554,28 @@ void List<T>::clear()
 template <typename T>
 void List<T>::insert(T const& rc_element, size_t const c_position)
 {
-      if (c_position > this->size()) {
-         this->push_back(rc_element);
-         return;
-      }
-      else if (c_position == 0U) {
-         this->push_front(rc_element);
-         return;
-      }
+   if (c_position > this->size())
+   {
+      this->push_back(rc_element);
+      return;
+   }
+   else if (c_position == 0U)
+   {
+      this->push_front(rc_element);
+      return;
+   }
 
    Node* current_node = this->mp_head;
-      for (size_t count{0U}; count < (c_position - 1U); ++count) {
-         current_node = current_node->mp_next_node;
-      }
+   for (size_t count{ 0U }; count < (c_position - 1U); ++count)
+   {
+      current_node = current_node->mp_next_node;
+   }
 
-   Node* new_node = new Node(rc_element);
-   new_node->mp_next_node = current_node->mp_next_node;
-   new_node->mp_prev_node = current_node;
+   Node* new_node             = new Node(rc_element);
+   new_node->mp_next_node     = current_node->mp_next_node;
+   new_node->mp_prev_node     = current_node;
    current_node->mp_next_node = new_node;
-   current_node = new_node->mp_next_node;
+   current_node               = new_node->mp_next_node;
    current_node->mp_prev_node = new_node;
 
    ++this->m_total_nodes;
@@ -569,42 +588,49 @@ template <typename T>
 void List<T>::insert(T const& rc_element, size_t const c_position,
                      size_t const c_count)
 {
-      if (c_count == 0U) {
-         return;
-      }
+   if (c_count == 0U)
+   {
+      return;
+   }
 
-      if (c_position > this->size()) {
-            for (size_t count{0U}; count < c_count; ++count) {
-               this->push_back(rc_element);
-            }
-         return;
+   if (c_position > this->size())
+   {
+      for (size_t count{ 0U }; count < c_count; ++count)
+      {
+         this->push_back(rc_element);
       }
-      else if (c_position == 0U) {
-            for (size_t count{0U}; count < c_count; ++count) {
-               this->push_front(rc_element);
-            }
-         return;
+      return;
+   }
+   else if (c_position == 0U)
+   {
+      for (size_t count{ 0U }; count < c_count; ++count)
+      {
+         this->push_front(rc_element);
       }
+      return;
+   }
 
    Node* current_node = this->mp_head;
-      for (size_t count{0U}; count < (c_position - 1U); ++count) {
-         current_node = current_node->mp_next_node;
-      }
+   for (size_t count{ 0U }; count < (c_position - 1U); ++count)
+   {
+      current_node = current_node->mp_next_node;
+   }
 
-   Node* new_node = new Node(rc_element);
+   Node* new_node  = new Node(rc_element);
    Node* temp_head = new_node;
    Node* temp_tail = new_node;
-      for (size_t count{1U}; count < c_count; ++count) {
-         new_node->mp_next_node = new Node(rc_element);
-         temp_tail = new_node->mp_next_node;
-         temp_tail->mp_prev_node = new_node;
-         new_node = new_node->mp_next_node;
-      }
+   for (size_t count{ 1U }; count < c_count; ++count)
+   {
+      new_node->mp_next_node  = new Node(rc_element);
+      temp_tail               = new_node->mp_next_node;
+      temp_tail->mp_prev_node = new_node;
+      new_node                = new_node->mp_next_node;
+   }
 
-   temp_tail->mp_next_node = current_node->mp_next_node;
-   temp_head->mp_prev_node = current_node;
+   temp_tail->mp_next_node    = current_node->mp_next_node;
+   temp_head->mp_prev_node    = current_node;
    current_node->mp_next_node = temp_head;
-   current_node = temp_tail->mp_next_node;
+   current_node               = temp_tail->mp_next_node;
    current_node->mp_prev_node = temp_tail;
    this->m_total_nodes += c_count;
 
@@ -616,11 +642,12 @@ template <typename T>
 void List<T>::insert(std::initializer_list<T> const& rc_element_list,
                      size_t const c_position)
 {
-   auto current_data_pos{c_position};
-      for (auto const& data : rc_element_list) {
-         this->insert(data, current_data_pos);
-         ++current_data_pos;
-      }
+   auto current_data_pos{ c_position };
+   for (auto const& data : rc_element_list)
+   {
+      this->insert(data, current_data_pos);
+      ++current_data_pos;
+   }
    return;
 }
 
@@ -628,19 +655,22 @@ void List<T>::insert(std::initializer_list<T> const& rc_element_list,
 template <typename T>
 void List<T>::remove_head_nodes(T const& rc_element)
 {
-      while ((this->mp_head != nullptr) &&
-             (rc_element == this->mp_head->m_node_data)) {
-         Node* temp_node = this->mp_head;
-         this->mp_head = this->mp_head->mp_next_node;
-            if (this->mp_head != nullptr) {
-               this->mp_head->mp_prev_node = nullptr;
-            }
-            else {
-               this->mp_tail = nullptr;
-            }
-         delete temp_node;
-         --this->m_total_nodes;
+   while ((this->mp_head != nullptr) &&
+          (rc_element == this->mp_head->m_node_data))
+   {
+      Node* temp_node = this->mp_head;
+      this->mp_head   = this->mp_head->mp_next_node;
+      if (this->mp_head != nullptr)
+      {
+         this->mp_head->mp_prev_node = nullptr;
       }
+      else
+      {
+         this->mp_tail = nullptr;
+      }
+      delete temp_node;
+      --this->m_total_nodes;
+   }
    return;
 }
 
@@ -648,14 +678,15 @@ void List<T>::remove_head_nodes(T const& rc_element)
 template <typename T>
 void List<T>::remove_tail_nodes(T const& rc_element)
 {
-      while ((this->mp_tail != nullptr) &&
-             (rc_element == this->mp_tail->m_node_data)) {
-         Node* temp_node = this->mp_tail;
-         this->mp_tail = this->mp_tail->mp_prev_node;
-         this->mp_tail->mp_next_node = nullptr;
-         delete temp_node;
-         --this->m_total_nodes;
-      }
+   while ((this->mp_tail != nullptr) &&
+          (rc_element == this->mp_tail->m_node_data))
+   {
+      Node* temp_node             = this->mp_tail;
+      this->mp_tail               = this->mp_tail->mp_prev_node;
+      this->mp_tail->mp_next_node = nullptr;
+      delete temp_node;
+      --this->m_total_nodes;
+   }
    return;
 }
 
@@ -663,25 +694,28 @@ void List<T>::remove_tail_nodes(T const& rc_element)
 template <typename T>
 bool List<T>::remove_middle_nodes(T const& rc_element)
 {
-   bool node_deleted{false};
+   bool node_deleted{ false };
    Node* current_node = this->mp_head;
-      while (current_node != nullptr) {
-            if (rc_element == current_node->m_node_data) {
-               Node* prev_node = current_node->mp_prev_node;
-               Node* next_node = current_node->mp_next_node;
-               Node* delete_node = current_node;
-               prev_node->mp_next_node = current_node->mp_next_node;
-               next_node->mp_prev_node = current_node->mp_prev_node;
-               current_node = current_node->mp_next_node;
-               delete delete_node;
+   while (current_node != nullptr)
+   {
+      if (rc_element == current_node->m_node_data)
+      {
+         Node* prev_node         = current_node->mp_prev_node;
+         Node* next_node         = current_node->mp_next_node;
+         Node* delete_node       = current_node;
+         prev_node->mp_next_node = current_node->mp_next_node;
+         next_node->mp_prev_node = current_node->mp_prev_node;
+         current_node            = current_node->mp_next_node;
+         delete delete_node;
 
-               --this->m_total_nodes;
-               node_deleted = true;
-            }
-            else {
-               current_node = current_node->mp_next_node;
-            }
+         --this->m_total_nodes;
+         node_deleted = true;
       }
+      else
+      {
+         current_node = current_node->mp_next_node;
+      }
+   }
    return node_deleted;
 }
 
@@ -689,34 +723,42 @@ bool List<T>::remove_middle_nodes(T const& rc_element)
 template <typename T>
 bool List<T>::remove(T const& rc_element)
 {
-   bool node_removed{false};
-      if (this->is_empty()) {
-         return false;
-      }
-      if (this->size() == 1U) {
-            if (rc_element == this->mp_head->m_node_data) {
-               this->clear();
-               node_removed = true;
-            }
-            else {
-               // NTD.
-            }
-      }
-      else {
-            // Handle head node deletion.
-            if (rc_element == this->mp_head->m_node_data) {
-               remove_head_nodes(rc_element);
-               node_removed = true;
-            }
-            // Handle tail node deletion.
-            if (rc_element == this->mp_tail->m_node_data) {
-               remove_tail_nodes(rc_element);
-               node_removed = true;
-            }
+   bool node_removed{ false };
+   if (this->is_empty())
+   {
+      return false;
+   }
 
-         // Handle middle node deletion.
-         node_removed |= remove_middle_nodes(rc_element);
+   if (this->size() == 1U)
+   {
+      if (rc_element == this->mp_head->m_node_data)
+      {
+         this->clear();
+         node_removed = true;
       }
+      else
+      {
+         // NTD.
+      }
+   }
+   else
+   {
+      // Handle head node deletion.
+      if (rc_element == this->mp_head->m_node_data)
+      {
+         remove_head_nodes(rc_element);
+         node_removed = true;
+      }
+      // Handle tail node deletion.
+      if (rc_element == this->mp_tail->m_node_data)
+      {
+         remove_tail_nodes(rc_element);
+         node_removed = true;
+      }
+
+      // Handle middle node deletion.
+      node_removed |= remove_middle_nodes(rc_element);
+   }
    return node_removed;
 }
 
@@ -724,15 +766,17 @@ bool List<T>::remove(T const& rc_element)
 template <typename T>
 void List<T>::copy_list(List<T> const& rc_list)
 {
-      if (!this->is_empty()) {
-         this->clear();
-      }
+   if (!this->is_empty())
+   {
+      this->clear();
+   }
 
    Node* current_node = rc_list.mp_head;
-      while (current_node != nullptr) {
-         this->push_back(current_node->m_node_data);
-         current_node = current_node->mp_next_node;
-      }
+   while (current_node != nullptr)
+   {
+      this->push_back(current_node->m_node_data);
+      current_node = current_node->mp_next_node;
+   }
 
    return;
 }
@@ -741,36 +785,38 @@ void List<T>::copy_list(List<T> const& rc_list)
 template <typename T>
 typename List<T>::Iterator List<T>::begin()
 {
-      if (this->is_empty()) {
-         return List<T>::Iterator{};
-      }
+   if (this->is_empty())
+   {
+      return List<T>::Iterator{};
+   }
 
-   return List<T>::Iterator{this->mp_head};
+   return List<T>::Iterator{ this->mp_head };
 }
 
 ////////////////////////////////////////////////////////////////////////////////////////////////////
 template <typename T>
 typename List<T>::Iterator List<T>::begin() const
 {
-      if (this->is_empty()) {
-         return List<T>::Iterator{};
-      }
+   if (this->is_empty())
+   {
+      return List<T>::Iterator{};
+   }
 
-   return List<T>::Iterator{this->mp_head};
+   return List<T>::Iterator{ this->mp_head };
 }
 
 ////////////////////////////////////////////////////////////////////////////////////////////////////
 template <typename T>
 typename List<T>::Iterator List<T>::end()
 {
-   return List<T>::Iterator{nullptr};
+   return List<T>::Iterator{ nullptr };
 }
 
 ////////////////////////////////////////////////////////////////////////////////////////////////////
 template <typename T>
 typename List<T>::Iterator List<T>::end() const
 {
-   return List<T>::Iterator{nullptr};
+   return List<T>::Iterator{ nullptr };
 }
 
 ////////////////////////////////////////////////////////////////////////////////////////////////////
@@ -780,7 +826,7 @@ typename List<T>::Iterator List<T>::end() const
 ////////////////////////////////////////////////////////////////////////////////////////////////////
 template <typename T>
 List<T>::Iterator::Iterator(List<T>::Node* cpc_starting_node)
-   : mp_current_node{cpc_starting_node}
+   : mp_current_node{ cpc_starting_node }
 {
    // Intentionally left empty.
 }
@@ -803,9 +849,10 @@ T const& List<T>::Iterator::operator*() const
 template <typename T>
 typename List<T>::Iterator& List<T>::Iterator::operator++()
 {
-      if (nullptr != this->mp_current_node) {
-         this->mp_current_node = this->mp_current_node->mp_next_node;
-      }
+   if (nullptr != this->mp_current_node)
+   {
+      this->mp_current_node = this->mp_current_node->mp_next_node;
+   }
 
    return *this;
 }
@@ -814,7 +861,7 @@ typename List<T>::Iterator& List<T>::Iterator::operator++()
 template <typename T>
 typename List<T>::Iterator List<T>::Iterator::operator++(int)
 {
-   List<T>::Iterator temp{*this};
+   List<T>::Iterator temp{ *this };
    operator++();
 
    return temp;

--- a/include/milky_way/list/list.h
+++ b/include/milky_way/list/list.h
@@ -27,15 +27,14 @@ class List
 private:
    struct Node
    {
-      Node(T const &rc_element)
-          : m_node_data{std::move(rc_element)}
+      Node(T const& rc_element) : m_node_data{std::move(rc_element)}
       {
          // Intentionally left empty.
       }
 
       T m_node_data{};
-      Node *mp_next_node{nullptr};
-      Node *mp_prev_node{nullptr};
+      Node* mp_next_node{nullptr};
+      Node* mp_prev_node{nullptr};
    };
 
 public:
@@ -47,7 +46,7 @@ public:
    /////////////////////////////////////////////////////////////////////////////////////////////////
    /// @brief Default constructor.
    /////////////////////////////////////////////////////////////////////////////////////////////////
-   explicit List(std::initializer_list<T> const &);
+   explicit List(std::initializer_list<T> const&);
 
    /////////////////////////////////////////////////////////////////////////////////////////////////
    /// @brief Destructor.
@@ -57,22 +56,22 @@ public:
    /////////////////////////////////////////////////////////////////////////////////////////////////
    /// @brief Copy constructor.
    /////////////////////////////////////////////////////////////////////////////////////////////////
-   List(List<T> const &);
+   List(List<T> const&);
 
    /////////////////////////////////////////////////////////////////////////////////////////////////
    /// @brief Copy assignment.
    /////////////////////////////////////////////////////////////////////////////////////////////////
-   List<T> &operator=(List<T> const &);
+   List<T>& operator=(List<T> const&);
 
    /////////////////////////////////////////////////////////////////////////////////////////////////
    /// @brief Copy assignment.
    /////////////////////////////////////////////////////////////////////////////////////////////////
-   List(List<T> &&) noexcept;
+   List(List<T>&&) noexcept;
 
    /////////////////////////////////////////////////////////////////////////////////////////////////
    /// @brief Move assignment.
    /////////////////////////////////////////////////////////////////////////////////////////////////
-   List<T> &operator=(List<T> &&) noexcept;
+   List<T>& operator=(List<T>&&) noexcept;
 
    /////////////////////////////////////////////////////////////////////////////////////////////////
    /// @brief Equality operator overloading.
@@ -89,48 +88,57 @@ public:
    ///
    /// @param[in] rc_element The element that needs to be inserted.
    /////////////////////////////////////////////////////////////////////////////////////////////////
-   void push_back(T const &rc_element);
+   void push_back(T const& rc_element);
 
    /////////////////////////////////////////////////////////////////////////////////////////////////
    /// @brief Pushes the element at the end of the list.
    ///
    /// @param[in] rc_element The element that needs to be inserted.
    /////////////////////////////////////////////////////////////////////////////////////////////////
-   void push_front(T const &rc_element);
+   void push_front(T const& rc_element);
 
    /////////////////////////////////////////////////////////////////////////////////////////////////
    /// @brief Inserts the provided list of elements.
    ///
    /// @param[in] rc_element The element that needs to be inserted.
-   /// @param[in] c_pos      The position where provided element needs to be inserted.
+   /// @param[in] c_pos      The position where provided element needs to be
+   /// inserted.
    ///
-   /// @note If provided position is greater than the list size, then the provided list of elements
+   /// @note If provided position is greater than the list size, then the
+   /// provided list of elements
    ///       are inserted at the end.
    /////////////////////////////////////////////////////////////////////////////////////////////////
-   void insert(T const &rc_element, size_t const c_pos);
+   void insert(T const& rc_element, size_t const c_pos);
 
    /////////////////////////////////////////////////////////////////////////////////////////////////
    /// @brief Inserts the provided list of elements.
    ///
    /// @param[in] rc_element The element that needs to be inserted.
-   /// @param[in] c_pos      The position where provided element needs to be inserted.
-   /// @param[in] c_count    The number of time provided element needs to be inserted.
+   /// @param[in] c_pos      The position where provided element needs to be
+   /// inserted.
+   /// @param[in] c_count    The number of time provided element needs to be
+   /// inserted.
    ///
-   /// @note If provided position is greater than the list size, then the provided list of elements
+   /// @note If provided position is greater than the list size, then the
+   /// provided list of elements
    ///       are inserted at the end.
    /////////////////////////////////////////////////////////////////////////////////////////////////
-   void insert(T const &rc_element, size_t const c_pos, size_t const c_count);
+   void insert(T const& rc_element, size_t const c_pos, size_t const c_count);
 
    /////////////////////////////////////////////////////////////////////////////////////////////////
    /// @brief Inserts the provided list of elements.
    ///
-   /// @param[in] rc_element_list The list of elements that needs to be inserted.
-   /// @param[in] c_pos           The position where provided list of elements need to be inserted.
+   /// @param[in] rc_element_list The list of elements that needs to be
+   /// inserted.
+   /// @param[in] c_pos           The position where provided list of
+   /// elements need to be inserted.
    ///
-   /// @note If provided position is greater than the list size, then the provided list of elements
+   /// @note If provided position is greater than the list size, then the
+   /// provided list of elements
    ///       are inserted at the end.
    /////////////////////////////////////////////////////////////////////////////////////////////////
-   void insert(std::initializer_list<T> const &rc_element_list, size_t const c_pos);
+   void insert(std::initializer_list<T> const& rc_element_list,
+               size_t const c_pos);
 
    /////////////////////////////////////////////////////////////////////////////////////////////////
    /// @brief Remove the provided element from the list.
@@ -139,7 +147,7 @@ public:
    ///
    /// @return True if element is removed successfully, otherwise false.
    /////////////////////////////////////////////////////////////////////////////////////////////////
-   bool remove(T const &rc_element);
+   bool remove(T const& rc_element);
 
    /////////////////////////////////////////////////////////////////////////////////////////////////
    /// @brief Destroys the list if it is non-empty.
@@ -167,31 +175,33 @@ public:
    ///
    /// @return True if element is found in the list, otherwise false.
    /////////////////////////////////////////////////////////////////////////////////////////////////
-   bool find(T const &rc_element) const;
+   bool find(T const& rc_element) const;
 
    /////////////////////////////////////////////////////////////////////////////////////////////////
    /// @brief Gets the first element in the list.
    ///
-   /// @return Reference to the first element if list is non-empty, otherwise undefined behaviour.
+   /// @return Reference to the first element if list is non-empty, otherwise
+   /// undefined behaviour.
    /////////////////////////////////////////////////////////////////////////////////////////////////
-   T const &front() const;
+   T const& front() const;
 
    /////////////////////////////////////////////////////////////////////////////////////////////////
    /// @overload T const &front() const
    /////////////////////////////////////////////////////////////////////////////////////////////////
-   T &front();
+   T& front();
 
    /////////////////////////////////////////////////////////////////////////////////////////////////
    /// @brief Gets the last element in the list.
    ///
-   /// @return Reference to the last element if list is non-empty, otherwise undefined behaviour.
+   /// @return Reference to the last element if list is non-empty, otherwise
+   /// undefined behaviour.
    /////////////////////////////////////////////////////////////////////////////////////////////////
-   T const &back() const;
+   T const& back() const;
 
    /////////////////////////////////////////////////////////////////////////////////////////////////
    /// @overload T const &back() const
    /////////////////////////////////////////////////////////////////////////////////////////////////
-   T &back();
+   T& back();
 
    /////////////////////////////////////////////////////////////////////////////////////////////////
    /// @brief Provides a way to access container's elements.
@@ -218,7 +228,7 @@ public:
       /// @overload T& operator*()
       //////////////////////////////////////////////////////////////////////////////////////////////
       T const& operator*() const;
-   
+
       //////////////////////////////////////////////////////////////////////////////////////////////
       /// @brief Pre-increment operator overloading.
       //////////////////////////////////////////////////////////////////////////////////////////////
@@ -248,13 +258,14 @@ public:
       Iterator& operator=(Iterator&&) noexcept = default;
 
    private:
-      List<T>::Node* mp_current_node{ nullptr };
+      List<T>::Node* mp_current_node{nullptr};
    };
 
    /////////////////////////////////////////////////////////////////////////////////////////////////
    /// @brief Gets an iterator pointing to a first element of the List.
    ///
-   /// @return Iterator pointing to first element of List if it is non-empty, otherwise undefined
+   /// @return Iterator pointing to first element of List if it is non-empty,
+   /// otherwise undefined
    ///         behaviour.
    /////////////////////////////////////////////////////////////////////////////////////////////////
    List<T>::Iterator begin();
@@ -265,9 +276,11 @@ public:
    List<T>::Iterator begin() const;
 
    /////////////////////////////////////////////////////////////////////////////////////////////////
-   /// @brief Gets an iterator pointing to one past the last element of the List.
+   /// @brief Gets an iterator pointing to one past the last element of the
+   /// List.
    ///
-   /// @return Iterator pointing to one past the last element of List if it is non-empty, otherwise
+   /// @return Iterator pointing to one past the last element of List if it
+   /// is non-empty, otherwise
    ///         undefined behaviour.
    /////////////////////////////////////////////////////////////////////////////////////////////////
    List<T>::Iterator end();
@@ -278,14 +291,14 @@ public:
    List<T>::Iterator end() const;
 
 private:
-   void remove_head_nodes(T const &);
-   void remove_tail_nodes(T const &);
-   bool remove_middle_nodes(T const &);
+   void remove_head_nodes(T const&);
+   void remove_tail_nodes(T const&);
+   bool remove_middle_nodes(T const&);
 
    void copy_list(List<T> const&);
 
-   Node *mp_head{nullptr};
-   Node *mp_tail{nullptr};
+   Node* mp_head{nullptr};
+   Node* mp_tail{nullptr};
    size_t m_total_nodes{0U};
 };
 
@@ -295,12 +308,11 @@ private:
 
 ////////////////////////////////////////////////////////////////////////////////////////////////////
 template <typename T>
-List<T>::List(std::initializer_list<T> const &rc_init_list)
+List<T>::List(std::initializer_list<T> const& rc_init_list)
 {
-   for (auto const &element : rc_init_list)
-   {
-      this->push_back(element);
-   }
+      for (auto const& element : rc_init_list) {
+         this->push_back(element);
+      }
 }
 
 ////////////////////////////////////////////////////////////////////////////////////////////////////
@@ -321,10 +333,9 @@ List<T>::List(List<T> const& rhs)
 template <typename T>
 List<T>& List<T>::operator=(List<T> const& rhs)
 {
-   if (this != &rhs)
-   {
-      this->copy_list(rhs);
-   }
+      if (this != &rhs) {
+         this->copy_list(rhs);
+      }
 
    return *this;
 }
@@ -348,18 +359,17 @@ List<T>::List(List<T>&& rhs) noexcept
 template <typename T>
 List<T>& List<T>::operator=(List<T>&& rhs) noexcept
 {
-   if (this != &rhs)
-   {
-      this->clear();
+      if (this != &rhs) {
+         this->clear();
 
-      this->mp_head = rhs.mp_head;
-      this->mp_tail = rhs.mp_tail;
-      this->m_total_nodes = rhs.m_total_nodes;
+         this->mp_head = rhs.mp_head;
+         this->mp_tail = rhs.mp_tail;
+         this->m_total_nodes = rhs.m_total_nodes;
 
-      rhs.mp_head = nullptr;
-      rhs.mp_head = nullptr;
-      rhs.m_total_nodes = 0U;
-   }
+         rhs.mp_head = nullptr;
+         rhs.mp_head = nullptr;
+         rhs.m_total_nodes = 0U;
+      }
 
    return *this;
 }
@@ -368,31 +378,28 @@ List<T>& List<T>::operator=(List<T>&& rhs) noexcept
 template <typename T>
 bool List<T>::operator==(List<T> const& rhs) const
 {
-   auto equality_result{ true };
-   if (this != &rhs)
-   {
-      if (this->size() != rhs.size())
-      {
-         equality_result = false;
-      }
-      else
-      {
-         Node const* lhs_current_node = this->mp_head;
-         Node const* rhs_current_node = rhs.mp_head;
-
-         while ((lhs_current_node != nullptr) && (rhs_current_node != nullptr))
-         {
-            if (lhs_current_node->m_node_data != rhs_current_node->m_node_data)
-            {
+   auto equality_result{true};
+      if (this != &rhs) {
+            if (this->size() != rhs.size()) {
                equality_result = false;
-               break;
             }
+            else {
+               Node const* lhs_current_node = this->mp_head;
+               Node const* rhs_current_node = rhs.mp_head;
 
-            lhs_current_node = lhs_current_node->mp_next_node;
-            rhs_current_node = rhs_current_node->mp_next_node;
-         }
+                  while ((lhs_current_node != nullptr) &&
+                         (rhs_current_node != nullptr)) {
+                        if (lhs_current_node->m_node_data !=
+                            rhs_current_node->m_node_data) {
+                           equality_result = false;
+                           break;
+                        }
+
+                     lhs_current_node = lhs_current_node->mp_next_node;
+                     rhs_current_node = rhs_current_node->mp_next_node;
+                  }
+            }
       }
-   }
 
    return equality_result;
 }
@@ -420,16 +427,17 @@ size_t List<T>::size() const
 
 ////////////////////////////////////////////////////////////////////////////////////////////////////
 template <typename T>
-void List<T>::push_back(T const &rc_element)
+void List<T>::push_back(T const& rc_element)
 {
-   if (this->is_empty()) {
-      this->mp_head = new Node(rc_element);
-      this->mp_tail = this->mp_head;
-   } else {
-      this->mp_tail->mp_next_node = new Node(rc_element);
-      this->mp_tail->mp_next_node->mp_prev_node = this->mp_tail;
-      this->mp_tail = this->mp_tail->mp_next_node;
-   }
+      if (this->is_empty()) {
+         this->mp_head = new Node(rc_element);
+         this->mp_tail = this->mp_head;
+      }
+      else {
+         this->mp_tail->mp_next_node = new Node(rc_element);
+         this->mp_tail->mp_next_node->mp_prev_node = this->mp_tail;
+         this->mp_tail = this->mp_tail->mp_next_node;
+      }
 
    ++this->m_total_nodes;
 
@@ -438,17 +446,18 @@ void List<T>::push_back(T const &rc_element)
 
 ////////////////////////////////////////////////////////////////////////////////////////////////////
 template <typename T>
-void List<T>::push_front(T const &rc_element)
+void List<T>::push_front(T const& rc_element)
 {
-   if (this->is_empty()) {
-      this->mp_head = new Node(rc_element);
-      this->mp_tail = this->mp_head;
-   } else {
-      Node *temp = new Node(rc_element);
-      temp->mp_next_node = this->mp_head;
-      this->mp_head->mp_prev_node = temp;
-      this->mp_head = this->mp_head->mp_prev_node;
-   }
+      if (this->is_empty()) {
+         this->mp_head = new Node(rc_element);
+         this->mp_tail = this->mp_head;
+      }
+      else {
+         Node* temp = new Node(rc_element);
+         temp->mp_next_node = this->mp_head;
+         this->mp_head->mp_prev_node = temp;
+         this->mp_head = this->mp_head->mp_prev_node;
+      }
 
    ++this->m_total_nodes;
 
@@ -457,51 +466,48 @@ void List<T>::push_front(T const &rc_element)
 
 ////////////////////////////////////////////////////////////////////////////////////////////////////
 template <typename T>
-bool List<T>::find(T const &rc_element) const
+bool List<T>::find(T const& rc_element) const
 {
-   if (this->is_empty())
-   {
-      return false;
-   }
+      if (this->is_empty()) {
+         return false;
+      }
 
    bool found{false};
-   Node *current_node = this->mp_head;
-   while (current_node != nullptr)
-   {
-      if (current_node->m_node_data == rc_element)
-      {
-         found = true;
+   Node* current_node = this->mp_head;
+      while (current_node != nullptr) {
+            if (current_node->m_node_data == rc_element) {
+               found = true;
+            }
+         current_node = current_node->mp_next_node;
       }
-      current_node = current_node->mp_next_node;
-   }
 
    return found;
 }
 
 ////////////////////////////////////////////////////////////////////////////////////////////////////
 template <typename T>
-T const &List<T>::front() const
+T const& List<T>::front() const
 {
    return this->mp_head->m_node_data;
 }
 
 ////////////////////////////////////////////////////////////////////////////////////////////////////
 template <typename T>
-T &List<T>::front()
+T& List<T>::front()
 {
    return this->mp_head->m_node_data;
 }
 
 ////////////////////////////////////////////////////////////////////////////////////////////////////
 template <typename T>
-T const &List<T>::back() const
+T const& List<T>::back() const
 {
    return this->mp_tail->m_node_data;
 }
 
 ////////////////////////////////////////////////////////////////////////////////////////////////////
 template <typename T>
-T &List<T>::back()
+T& List<T>::back()
 {
    return this->mp_tail->m_node_data;
 }
@@ -510,19 +516,17 @@ T &List<T>::back()
 template <typename T>
 void List<T>::clear()
 {
-   if (this->is_empty())
-   {
-      return;
-   }
+      if (this->is_empty()) {
+         return;
+      }
 
-   Node *current_node = this->mp_head;
-   while (current_node != nullptr)
-   {
-      Node *temp_node = current_node;
-      current_node = current_node->mp_next_node;
-      delete temp_node;
-      --this->m_total_nodes;
-   }
+   Node* current_node = this->mp_head;
+      while (current_node != nullptr) {
+         Node* temp_node = current_node;
+         current_node = current_node->mp_next_node;
+         delete temp_node;
+         --this->m_total_nodes;
+      }
 
    this->mp_head = nullptr;
    this->mp_tail = nullptr;
@@ -532,26 +536,23 @@ void List<T>::clear()
 
 ////////////////////////////////////////////////////////////////////////////////////////////////////
 template <typename T>
-void List<T>::insert(T const &rc_element, size_t const c_position)
+void List<T>::insert(T const& rc_element, size_t const c_position)
 {
-   if (c_position > this->size())
-   {
-      this->push_back(rc_element);
-      return;
-   }
-   else if (c_position == 0U)
-   {
-      this->push_front(rc_element);
-      return;
-   }
+      if (c_position > this->size()) {
+         this->push_back(rc_element);
+         return;
+      }
+      else if (c_position == 0U) {
+         this->push_front(rc_element);
+         return;
+      }
 
-   Node *current_node = this->mp_head;
-   for (size_t count{0U}; count < (c_position - 1U); ++count)
-   {
-      current_node = current_node->mp_next_node;
-   }
+   Node* current_node = this->mp_head;
+      for (size_t count{0U}; count < (c_position - 1U); ++count) {
+         current_node = current_node->mp_next_node;
+      }
 
-   Node *new_node = new Node(rc_element);
+   Node* new_node = new Node(rc_element);
    new_node->mp_next_node = current_node->mp_next_node;
    new_node->mp_prev_node = current_node;
    current_node->mp_next_node = new_node;
@@ -565,46 +566,40 @@ void List<T>::insert(T const &rc_element, size_t const c_position)
 
 ////////////////////////////////////////////////////////////////////////////////////////////////////
 template <typename T>
-void List<T>::insert(T const &rc_element, size_t const c_position, size_t const c_count)
+void List<T>::insert(T const& rc_element, size_t const c_position,
+                     size_t const c_count)
 {
-   if (c_count == 0U)
-   {
-      return;
-   }
-
-   if (c_position > this->size())
-   {
-      for (size_t count{0U}; count < c_count; ++count)
-      {
-         this->push_back(rc_element);
+      if (c_count == 0U) {
+         return;
       }
-      return;
-   }
-   else if (c_position == 0U)
-   {
-      for (size_t count{0U}; count < c_count; ++count)
-      {
-         this->push_front(rc_element);
+
+      if (c_position > this->size()) {
+            for (size_t count{0U}; count < c_count; ++count) {
+               this->push_back(rc_element);
+            }
+         return;
       }
-      return;
-   }
+      else if (c_position == 0U) {
+            for (size_t count{0U}; count < c_count; ++count) {
+               this->push_front(rc_element);
+            }
+         return;
+      }
 
-   Node *current_node = this->mp_head;
-   for (size_t count{0U}; count < (c_position - 1U); ++count)
-   {
-      current_node = current_node->mp_next_node;
-   }
+   Node* current_node = this->mp_head;
+      for (size_t count{0U}; count < (c_position - 1U); ++count) {
+         current_node = current_node->mp_next_node;
+      }
 
-   Node *new_node = new Node(rc_element);
-   Node *temp_head = new_node;
-   Node *temp_tail = new_node;
-   for (size_t count{1U}; count < c_count; ++count)
-   {
-      new_node->mp_next_node = new Node(rc_element);
-      temp_tail = new_node->mp_next_node;
-      temp_tail->mp_prev_node = new_node;
-      new_node = new_node->mp_next_node;
-   }
+   Node* new_node = new Node(rc_element);
+   Node* temp_head = new_node;
+   Node* temp_tail = new_node;
+      for (size_t count{1U}; count < c_count; ++count) {
+         new_node->mp_next_node = new Node(rc_element);
+         temp_tail = new_node->mp_next_node;
+         temp_tail->mp_prev_node = new_node;
+         new_node = new_node->mp_next_node;
+      }
 
    temp_tail->mp_next_node = current_node->mp_next_node;
    temp_head->mp_prev_node = current_node;
@@ -618,122 +613,110 @@ void List<T>::insert(T const &rc_element, size_t const c_position, size_t const 
 
 ////////////////////////////////////////////////////////////////////////////////////////////////////
 template <typename T>
-void List<T>::insert(std::initializer_list<T> const &rc_element_list, size_t const c_position)
+void List<T>::insert(std::initializer_list<T> const& rc_element_list,
+                     size_t const c_position)
 {
    auto current_data_pos{c_position};
-   for (auto const &data : rc_element_list)
-   {
-      this->insert(data, current_data_pos);
-      ++current_data_pos;
-   }
-   return;
-}
-
-////////////////////////////////////////////////////////////////////////////////////////////////////
-template <typename T>
-void List<T>::remove_head_nodes(T const &rc_element)
-{
-   while ((this->mp_head != nullptr) && (rc_element == this->mp_head->m_node_data))
-   {
-      Node *temp_node = this->mp_head;
-      this->mp_head = this->mp_head->mp_next_node;
-      if (this->mp_head != nullptr)
-      {
-         this->mp_head->mp_prev_node = nullptr;
+      for (auto const& data : rc_element_list) {
+         this->insert(data, current_data_pos);
+         ++current_data_pos;
       }
-      else
-      {
-         this->mp_tail = nullptr;
-      }
-      delete temp_node;
-      --this->m_total_nodes;
-   }
    return;
 }
 
 ////////////////////////////////////////////////////////////////////////////////////////////////////
 template <typename T>
-void List<T>::remove_tail_nodes(T const &rc_element)
+void List<T>::remove_head_nodes(T const& rc_element)
 {
-   while ((this->mp_tail != nullptr) && (rc_element == this->mp_tail->m_node_data))
-   {
-      Node *temp_node = this->mp_tail;
-      this->mp_tail = this->mp_tail->mp_prev_node;
-      this->mp_tail->mp_next_node = nullptr;
-      delete temp_node;
-      --this->m_total_nodes;
-   }
+      while ((this->mp_head != nullptr) &&
+             (rc_element == this->mp_head->m_node_data)) {
+         Node* temp_node = this->mp_head;
+         this->mp_head = this->mp_head->mp_next_node;
+            if (this->mp_head != nullptr) {
+               this->mp_head->mp_prev_node = nullptr;
+            }
+            else {
+               this->mp_tail = nullptr;
+            }
+         delete temp_node;
+         --this->m_total_nodes;
+      }
    return;
 }
 
 ////////////////////////////////////////////////////////////////////////////////////////////////////
 template <typename T>
-bool List<T>::remove_middle_nodes(T const &rc_element)
+void List<T>::remove_tail_nodes(T const& rc_element)
+{
+      while ((this->mp_tail != nullptr) &&
+             (rc_element == this->mp_tail->m_node_data)) {
+         Node* temp_node = this->mp_tail;
+         this->mp_tail = this->mp_tail->mp_prev_node;
+         this->mp_tail->mp_next_node = nullptr;
+         delete temp_node;
+         --this->m_total_nodes;
+      }
+   return;
+}
+
+////////////////////////////////////////////////////////////////////////////////////////////////////
+template <typename T>
+bool List<T>::remove_middle_nodes(T const& rc_element)
 {
    bool node_deleted{false};
-   Node *current_node = this->mp_head;
-   while (current_node != nullptr)
-   {
-      if (rc_element == current_node->m_node_data)
-      {
-         Node *prev_node = current_node->mp_prev_node;
-         Node *next_node = current_node->mp_next_node;
-         Node *delete_node = current_node;
-         prev_node->mp_next_node = current_node->mp_next_node;
-         next_node->mp_prev_node = current_node->mp_prev_node;
-         current_node = current_node->mp_next_node;
-         delete delete_node;
+   Node* current_node = this->mp_head;
+      while (current_node != nullptr) {
+            if (rc_element == current_node->m_node_data) {
+               Node* prev_node = current_node->mp_prev_node;
+               Node* next_node = current_node->mp_next_node;
+               Node* delete_node = current_node;
+               prev_node->mp_next_node = current_node->mp_next_node;
+               next_node->mp_prev_node = current_node->mp_prev_node;
+               current_node = current_node->mp_next_node;
+               delete delete_node;
 
-         --this->m_total_nodes;
-         node_deleted = true;
+               --this->m_total_nodes;
+               node_deleted = true;
+            }
+            else {
+               current_node = current_node->mp_next_node;
+            }
       }
-      else
-      {
-         current_node = current_node->mp_next_node;
-      }
-   }
    return node_deleted;
 }
 
 ////////////////////////////////////////////////////////////////////////////////////////////////////
 template <typename T>
-bool List<T>::remove(T const &rc_element)
+bool List<T>::remove(T const& rc_element)
 {
    bool node_removed{false};
-   if (this->is_empty())
-   {
-      return false;
-   }
-   if (this->size() == 1U)
-   {
-      if (rc_element == this->mp_head->m_node_data)
-      {
-         this->clear();
-         node_removed = true;
+      if (this->is_empty()) {
+         return false;
       }
-      else
-      {
-         // NTD.
+      if (this->size() == 1U) {
+            if (rc_element == this->mp_head->m_node_data) {
+               this->clear();
+               node_removed = true;
+            }
+            else {
+               // NTD.
+            }
       }
-   }
-   else
-   {
-      // Handle head node deletion.
-      if (rc_element == this->mp_head->m_node_data)
-      {
-         remove_head_nodes(rc_element);
-         node_removed = true;
-      }
-      // Handle tail node deletion.
-      if (rc_element == this->mp_tail->m_node_data)
-      {
-         remove_tail_nodes(rc_element);
-         node_removed = true;
-      }
+      else {
+            // Handle head node deletion.
+            if (rc_element == this->mp_head->m_node_data) {
+               remove_head_nodes(rc_element);
+               node_removed = true;
+            }
+            // Handle tail node deletion.
+            if (rc_element == this->mp_tail->m_node_data) {
+               remove_tail_nodes(rc_element);
+               node_removed = true;
+            }
 
-      // Handle middle node deletion.
-      node_removed |= remove_middle_nodes(rc_element);
-   }
+         // Handle middle node deletion.
+         node_removed |= remove_middle_nodes(rc_element);
+      }
    return node_removed;
 }
 
@@ -741,17 +724,15 @@ bool List<T>::remove(T const &rc_element)
 template <typename T>
 void List<T>::copy_list(List<T> const& rc_list)
 {
-   if (!this->is_empty())
-   {
-      this->clear();
-   }
+      if (!this->is_empty()) {
+         this->clear();
+      }
 
    Node* current_node = rc_list.mp_head;
-   while (current_node != nullptr)
-   {
-      this->push_back(current_node->m_node_data);
-      current_node = current_node->mp_next_node;
-   }
+      while (current_node != nullptr) {
+         this->push_back(current_node->m_node_data);
+         current_node = current_node->mp_next_node;
+      }
 
    return;
 }
@@ -760,38 +741,36 @@ void List<T>::copy_list(List<T> const& rc_list)
 template <typename T>
 typename List<T>::Iterator List<T>::begin()
 {
-   if (this->is_empty())
-   {
-      return List<T>::Iterator{};
-   }
+      if (this->is_empty()) {
+         return List<T>::Iterator{};
+      }
 
-   return List<T>::Iterator{ this->mp_head };
+   return List<T>::Iterator{this->mp_head};
 }
 
 ////////////////////////////////////////////////////////////////////////////////////////////////////
 template <typename T>
 typename List<T>::Iterator List<T>::begin() const
 {
-   if (this->is_empty())
-   {
-      return List<T>::Iterator{};
-   }
+      if (this->is_empty()) {
+         return List<T>::Iterator{};
+      }
 
-   return List<T>::Iterator{ this->mp_head };
+   return List<T>::Iterator{this->mp_head};
 }
 
 ////////////////////////////////////////////////////////////////////////////////////////////////////
 template <typename T>
 typename List<T>::Iterator List<T>::end()
 {
-   return List<T>::Iterator{ nullptr };
+   return List<T>::Iterator{nullptr};
 }
 
 ////////////////////////////////////////////////////////////////////////////////////////////////////
 template <typename T>
 typename List<T>::Iterator List<T>::end() const
 {
-   return List<T>::Iterator{ nullptr };
+   return List<T>::Iterator{nullptr};
 }
 
 ////////////////////////////////////////////////////////////////////////////////////////////////////
@@ -801,7 +780,7 @@ typename List<T>::Iterator List<T>::end() const
 ////////////////////////////////////////////////////////////////////////////////////////////////////
 template <typename T>
 List<T>::Iterator::Iterator(List<T>::Node* cpc_starting_node)
-   : mp_current_node{ cpc_starting_node }
+   : mp_current_node{cpc_starting_node}
 {
    // Intentionally left empty.
 }
@@ -824,10 +803,9 @@ T const& List<T>::Iterator::operator*() const
 template <typename T>
 typename List<T>::Iterator& List<T>::Iterator::operator++()
 {
-   if (nullptr != this->mp_current_node)
-   {
-      this->mp_current_node = this->mp_current_node->mp_next_node;
-   }
+      if (nullptr != this->mp_current_node) {
+         this->mp_current_node = this->mp_current_node->mp_next_node;
+      }
 
    return *this;
 }
@@ -836,7 +814,7 @@ typename List<T>::Iterator& List<T>::Iterator::operator++()
 template <typename T>
 typename List<T>::Iterator List<T>::Iterator::operator++(int)
 {
-   List<T>::Iterator temp{ *this };
+   List<T>::Iterator temp{*this};
    operator++();
 
    return temp;
@@ -856,7 +834,7 @@ bool List<T>::Iterator::operator!=(Iterator const& rhs) const
    return !(*this == rhs);
 }
 
-} // namespace MilkyWay
-} // namespace Prashant
+}  // namespace MilkyWay
+}  // namespace Prashant
 
-#endif // PRASHANT_MILKY_WAY_LIST_LIST_H
+#endif  // PRASHANT_MILKY_WAY_LIST_LIST_H

--- a/tests/unit/list/list_iterator_tests.cpp
+++ b/tests/unit/list/list_iterator_tests.cpp
@@ -5,13 +5,13 @@
 ////////////////////////////////////////////////////////////////////////////////////////////////////
 // Include(s)
 ////////////////////////////////////////////////////////////////////////////////////////////////////
-#include <array>
-#include <cstdint>
-#include <string>
-
 #include "gmock/gmock.h"
 #include "gtest/gtest.h"
 #include "milky_way/list/list.h"
+
+#include <array>
+#include <cstdint>
+#include <string>
 
 ////////////////////////////////////////////////////////////////////////////////////////////////////
 /// Namespace(s)
@@ -34,9 +34,10 @@ protected:
    /////////////////////////////////////////////////////////////////////////////////////////////////
    void SetUp() override
    {
-         for (auto const& element : list_elemets) {
-            test_list.push_back(element);
-         }
+      for (auto const& element : list_elemets)
+      {
+         test_list.push_back(element);
+      }
    }
 
    /////////////////////////////////////////////////////////////////////////////////////////////////
@@ -44,7 +45,7 @@ protected:
    /////////////////////////////////////////////////////////////////////////////////////////////////
    void TearDown() override { test_list.clear(); }
 
-   std::array<uint32_t, 5U> const list_elemets{23U, 87U, 226U, 89347U, 1244U};
+   std::array<uint32_t, 5U> const list_elemets{ 23U, 87U, 226U, 89347U, 1244U };
    List<uint32_t> test_list{};
 };
 
@@ -55,7 +56,7 @@ TEST_F(
 {
    // Given - A List iterator,
    std::string const first_element = "TEST";
-   List<std::string> test_list{first_element, "LIST"};
+   List<std::string> test_list{ first_element, "LIST" };
 
    // When - Begin() is called,
    auto const it = test_list.begin();
@@ -71,10 +72,11 @@ TEST_F(
 {
    // Given - A List iterator,
    // When - Elements are counted using for loop,
-   size_t count{0U};
-      for (auto it = test_list.begin(); it != test_list.end(); ++it) {
-         ++count;
-      }
+   size_t count{ 0U };
+   for (auto it = test_list.begin(); it != test_list.end(); ++it)
+   {
+      ++count;
+   }
 
    // Then - Counted elements should be equal to list size.
    EXPECT_EQ(count, test_list.size());
@@ -87,14 +89,15 @@ TEST_F(
 {
    // Given - A List iterator,
    auto it = test_list.begin();
-   size_t idx{0U};
+   size_t idx{ 0U };
 
-      // When - Post-increment is called,
-      // Then - Correct results are returned.
-      for (auto it = test_list.begin(); it != test_list.end(); it++) {
-         EXPECT_EQ(*it, list_elemets[idx]);
-         ++idx;
-      }
+   // When - Post-increment is called,
+   // Then - Correct results are returned.
+   for (auto it = test_list.begin(); it != test_list.end(); it++)
+   {
+      EXPECT_EQ(*it, list_elemets[idx]);
+      ++idx;
+   }
 }
 
 ////////////////////////////////////////////////////////////////////////////////////////////////////
@@ -106,12 +109,13 @@ TEST_F(
    auto it = test_list.begin();
 
    // When - Range based for loop is called,
-   size_t idx{0U};
-      for (auto const& element : test_list) {
-         // Then - Loop works as expected.
-         EXPECT_EQ(element, list_elemets[idx]);
-         ++idx;
-      }
+   size_t idx{ 0U };
+   for (auto const& element : test_list)
+   {
+      // Then - Loop works as expected.
+      EXPECT_EQ(element, list_elemets[idx]);
+      ++idx;
+   }
 }
 
 ////////////////////////////////////////////////////////////////////////////////////////////////////
@@ -123,7 +127,7 @@ TEST_F(
    auto it = test_list.begin();
 
    // When - An iterator is used to modify list content,
-   uint32_t const updated_value{70U};
+   uint32_t const updated_value{ 70U };
    *it = updated_value;
 
    // Then - List is updated.

--- a/tests/unit/list/list_iterator_tests.cpp
+++ b/tests/unit/list/list_iterator_tests.cpp
@@ -2,18 +2,16 @@
 // Copyright (c) 2024 Prashant Gandhi - All rights are reserved
 ////////////////////////////////////////////////////////////////////////////////////////////////////
 
-
 ////////////////////////////////////////////////////////////////////////////////////////////////////
 // Include(s)
 ////////////////////////////////////////////////////////////////////////////////////////////////////
-#include "gtest/gtest.h"
-#include "gmock/gmock.h"
-
-#include "milky_way/list/list.h"
-
 #include <array>
 #include <cstdint>
 #include <string>
+
+#include "gmock/gmock.h"
+#include "gtest/gtest.h"
+#include "milky_way/list/list.h"
 
 ////////////////////////////////////////////////////////////////////////////////////////////////////
 /// Namespace(s)
@@ -35,33 +33,29 @@ protected:
    /// @brief Setup function.
    /////////////////////////////////////////////////////////////////////////////////////////////////
    void SetUp() override
-   {   
-      for (auto const& element : list_elemets)
-      {
-         test_list.push_back(element);
-      }
+   {
+         for (auto const& element : list_elemets) {
+            test_list.push_back(element);
+         }
    }
 
    /////////////////////////////////////////////////////////////////////////////////////////////////
    /// @brief TearDown function.
    /////////////////////////////////////////////////////////////////////////////////////////////////
-   void TearDown() override
-   {
-      test_list.clear();
-   }
+   void TearDown() override { test_list.clear(); }
 
-   std::array<uint32_t, 5U> const list_elemets{ 23U, 87U, 226U, 89347U, 1244U };
+   std::array<uint32_t, 5U> const list_elemets{23U, 87U, 226U, 89347U, 1244U};
    List<uint32_t> test_list{};
 };
 
 ////////////////////////////////////////////////////////////////////////////////////////////////////
 TEST_F(
-   ListIteratorTest, 
+   ListIteratorTest,
    Given_AListIterator_When_BeginIsCalled_Then_IteratorPointingToFirstElementIsReturned)
 {
    // Given - A List iterator,
    std::string const first_element = "TEST";
-   List<std::string> test_list{ first_element, "LIST" };
+   List<std::string> test_list{first_element, "LIST"};
 
    // When - Begin() is called,
    auto const it = test_list.begin();
@@ -72,66 +66,69 @@ TEST_F(
 
 ////////////////////////////////////////////////////////////////////////////////////////////////////
 TEST_F(
-   ListIteratorTest, 
+   ListIteratorTest,
    Given_AListIterator_When_ElementsAreCountedUsingForLoop_Then_CountedElementsShouldBeEqualToListSize)
 {
    // Given - A List iterator,
    // When - Elements are counted using for loop,
-   size_t count{ 0U };
-   for (auto it = test_list.begin(); it != test_list.end(); ++it)
-   {
-      ++count;
-   }
+   size_t count{0U};
+      for (auto it = test_list.begin(); it != test_list.end(); ++it) {
+         ++count;
+      }
 
    // Then - Counted elements should be equal to list size.
    EXPECT_EQ(count, test_list.size());
 }
 
 ////////////////////////////////////////////////////////////////////////////////////////////////////
-TEST_F(ListIteratorTest, Given_AListIterator_When_PostIncrementIsCalled_Then_CorrectResultsAreReturned)
+TEST_F(
+   ListIteratorTest,
+   Given_AListIterator_When_PostIncrementIsCalled_Then_CorrectResultsAreReturned)
 {
    // Given - A List iterator,
    auto it = test_list.begin();
-   size_t idx{ 0U };
+   size_t idx{0U};
 
-   // When - Post-increment is called,
-   // Then - Correct results are returned.
-   for (auto it = test_list.begin(); it != test_list.end(); it++)
-   {
-      EXPECT_EQ(*it, list_elemets[idx]);
-      ++idx;
-   }
+      // When - Post-increment is called,
+      // Then - Correct results are returned.
+      for (auto it = test_list.begin(); it != test_list.end(); it++) {
+         EXPECT_EQ(*it, list_elemets[idx]);
+         ++idx;
+      }
 }
 
 ////////////////////////////////////////////////////////////////////////////////////////////////////
-TEST_F(ListIteratorTest, Given_AListIterator_When_RangBasedForLoopIsCalled_Then_LoopWorksAsExpected)
+TEST_F(
+   ListIteratorTest,
+   Given_AListIterator_When_RangBasedForLoopIsCalled_Then_LoopWorksAsExpected)
 {
    // Given - A List iterator,
    auto it = test_list.begin();
 
    // When - Range based for loop is called,
-   size_t idx{ 0U };
-   for (auto const& element : test_list)
-   {      
-      // Then - Loop works as expected.
-      EXPECT_EQ(element, list_elemets[idx]);
-      ++idx;
-   }
+   size_t idx{0U};
+      for (auto const& element : test_list) {
+         // Then - Loop works as expected.
+         EXPECT_EQ(element, list_elemets[idx]);
+         ++idx;
+      }
 }
 
 ////////////////////////////////////////////////////////////////////////////////////////////////////
-TEST_F(ListIteratorTest, Given_AListIterator_When_IteratorIsUsedToModifyListContent_Then_ListIsUpdated)
+TEST_F(
+   ListIteratorTest,
+   Given_AListIterator_When_IteratorIsUsedToModifyListContent_Then_ListIsUpdated)
 {
    // Given - A List iterator,
    auto it = test_list.begin();
 
    // When - An iterator is used to modify list content,
-   uint32_t const updated_value{ 70U };
+   uint32_t const updated_value{70U};
    *it = updated_value;
 
    // Then - List is updated.
    EXPECT_THAT(test_list.front(), Eq(updated_value));
 }
 
-} // namespace MilkyWay
-} // namespace Prashant
+}  // namespace MilkyWay
+}  // namespace Prashant

--- a/tests/unit/list/list_tests.cpp
+++ b/tests/unit/list/list_tests.cpp
@@ -5,12 +5,12 @@
 ////////////////////////////////////////////////////////////////////////////////////////////////////
 // Include(s)
 ////////////////////////////////////////////////////////////////////////////////////////////////////
-#include <cstdint>
-#include <string>
-
 #include "gmock/gmock.h"
 #include "gtest/gtest.h"
 #include "milky_way/list/list.h"
+
+#include <cstdint>
+#include <string>
 
 ////////////////////////////////////////////////////////////////////////////////////////////////////
 // Namespace(s)
@@ -57,7 +57,7 @@ TEST_F(ListTest,
        Given_AListObjWithElements_When_IsEmptyIsCalled_Then_FalseIsReturned)
 {
    // Given - A List object with no element,
-   List<uint32_t> test_list{1U, 2U, 3U};
+   List<uint32_t> test_list{ 1U, 2U, 3U };
 
    // When - is_empty() is called,
    // Then - False is returned
@@ -81,8 +81,8 @@ TEST_F(ListTest,
        Given_AListObjWithElements_When_SizeIsCalled_Then_ExpectedSizeIsReturned)
 {
    // Given - A List object with no element,
-   List<std::string> test_list{std::string("First"), std::string("Sec"),
-                               std::string("Third")};
+   List<std::string> test_list{ std::string("First"), std::string("Sec"),
+                                std::string("Third") };
 
    // When - size() is called,
    // Then - Expected size is returned
@@ -95,10 +95,10 @@ TEST_F(
    Given_AListObj_When_AnElementIsPushedAtBack_Then_AnElementIsAddedAtCorrectLocation)
 {
    // Given - A List,
-   List<int32_t> test_list{78, 98, 547};
+   List<int32_t> test_list{ 78, 98, 547 };
 
    // When - An element is pushed at back,
-   int const new_element{70};
+   int const new_element{ 70 };
    test_list.push_back(new_element);
    auto const back_element = test_list.back();
 
@@ -114,10 +114,10 @@ TEST_F(
    Given_AListObj_When_AnElementIsPushedAtBeginning_Then_AnElementIsAddedAtCorrectLocation)
 {
    // Given - A List,
-   List<int32_t> test_list{78, 98, 547};
+   List<int32_t> test_list{ 78, 98, 547 };
 
    // When - An element is pushed at the beginning,
-   int const new_element{70};
+   int const new_element{ 70 };
    test_list.push_front(new_element);
    auto const back_element = test_list.back();
 
@@ -132,7 +132,7 @@ TEST_F(ListTest,
        Given_ANonEmptyList_When_ExistingElementIsSearched_Then_TrueIsReturned)
 {
    // Given - A non-empty List,
-   List<int32_t> test_list{78, 98, 547};
+   List<int32_t> test_list{ 78, 98, 547 };
 
    // When - An existing element is searched,
    // Then - True is returned.
@@ -145,7 +145,7 @@ TEST_F(
    Given_ANonEmptyList_When_NonExistingElementIsSearched_Then_TrueIsReturned)
 {
    // Given - A non-empty List,
-   List<int32_t> test_list{78, 98, 547};
+   List<int32_t> test_list{ 78, 98, 547 };
 
    // When - A non existing element is searched,
    // Then - False is returned.
@@ -157,7 +157,7 @@ TEST_F(ListTest,
        Given_ANonEmptyList_When_ClearIsCalled_Then_AllElementsShouldBeRemoved)
 {
    // Given - A non-empty List,
-   List<int32_t> test_list{78, 98, 547};
+   List<int32_t> test_list{ 78, 98, 547 };
 
    // When - clear() is called,
    test_list.clear();
@@ -173,7 +173,7 @@ TEST_F(
    Given_ANonEmptyList_When_ExistingElementIsRemoved_Then_ElementShouldNotBePresentInList)
 {
    // Given - A non-empty List,
-   List<int32_t> test_list{78, 98, 547};
+   List<int32_t> test_list{ 78, 98, 547 };
 
    // When - An existing element is removed,
    // Then - An element should not be present in list.
@@ -193,7 +193,7 @@ TEST_F(
    Given_ANonEmptyList_When_ListObjIsComparedWithItselfUsingEqualityOperator_Then_TrueIsReturned)
 {
    // Given - A non-empty string,
-   List<uint8_t> const test_list{4U, 7U, 9U, 78U};
+   List<uint8_t> const test_list{ 4U, 7U, 9U, 78U };
 
    // When - List object is compared with itself using equality(==) operator,
    // Then - True is returned.
@@ -206,8 +206,8 @@ TEST_F(
    Given_TwoNonEmptyList_When_ListObjIsComparedWithAnotherListContainingSameElementsEqualityOperator_Then_TrueIsReturned)
 {
    // Given - Two non-empty string,
-   List<uint8_t> const test_list_1{4U, 7U, 9U, 78U};
-   List<uint8_t> const test_list_2{4U, 7U, 9U, 78U};
+   List<uint8_t> const test_list_1{ 4U, 7U, 9U, 78U };
+   List<uint8_t> const test_list_2{ 4U, 7U, 9U, 78U };
 
    // When - List object is compared with another list containing same elements
    // using equality(==)
@@ -222,8 +222,8 @@ TEST_F(
    Given_TwoNonEmptyList_When_ListObjIsComparedWithAnotherListContainingDifferentElementsEqualityOperator_Then_FalseIsReturned)
 {
    // Given - Two non-empty string,
-   List<uint8_t> const test_list_1{4U, 7U, 9U, 78U};
-   List<uint8_t> const test_list_2{4U, 7U, 9U, 75U};
+   List<uint8_t> const test_list_1{ 4U, 7U, 9U, 78U };
+   List<uint8_t> const test_list_2{ 4U, 7U, 9U, 75U };
 
    // When - List object is compared with another list containing different
    // elements using
@@ -242,7 +242,7 @@ TEST_F(
    Given_ANonEmptyList_When_ListObjIsComparedWithItselfUsingInequalityOperator_Then_FalseIsReturned)
 {
    // Given - A non-empty string,
-   List<uint8_t> const test_list{4U, 7U, 9U, 78U};
+   List<uint8_t> const test_list{ 4U, 7U, 9U, 78U };
 
    // When - List object is compared with itself using inequality(!=) operator,
    // Then - False is returned.
@@ -255,8 +255,8 @@ TEST_F(
    Given_TwoNonEmptyList_When_ListObjIsComparedWithAnotherListContainingSameElementsInequalityOperator_Then_FalseIsReturned)
 {
    // Given - Two non-empty string,
-   List<uint8_t> const test_list_1{4U, 7U, 9U, 78U};
-   List<uint8_t> const test_list_2{4U, 7U, 9U, 78U};
+   List<uint8_t> const test_list_1{ 4U, 7U, 9U, 78U };
+   List<uint8_t> const test_list_2{ 4U, 7U, 9U, 78U };
 
    // When - List object is compared with another list containing same elements
    // using inequality(!=)
@@ -271,8 +271,8 @@ TEST_F(
    Given_TwoNonEmptyList_When_ListObjIsComparedWithAnotherListContainingDifferentElementsInequalityOperator_Then_TrueIsReturned)
 {
    // Given - Two non-empty string,
-   List<uint8_t> const test_list_1{4U, 7U, 9U, 78U};
-   List<uint8_t> const test_list_2{4U, 7U, 9U, 75U};
+   List<uint8_t> const test_list_1{ 4U, 7U, 9U, 78U };
+   List<uint8_t> const test_list_2{ 4U, 7U, 9U, 75U };
 
    // When - List object is compared with another list containing different
    // elements using
@@ -291,7 +291,7 @@ TEST_F(
    Given_ANonEmptyList_When_CopyCtorIsUsedToCopyList_Then_CopiedListContainsSameData)
 {
    // Given - A non-empty string,
-   List<uint8_t> const test_list{4U, 7U, 9U, 78U};
+   List<uint8_t> const test_list{ 4U, 7U, 9U, 78U };
 
    // When - Copy constructor is used to copy list,
    auto const copy_list = test_list;
@@ -313,7 +313,7 @@ TEST_F(
    Given_ANonEmptyList_When_CopyAssignmentIsUsedToCopyList_Then_CopiedListContainsSameData)
 {
    // Given - A non-empty string,
-   List<uint8_t> const test_list{4U, 7U, 9U, 78U};
+   List<uint8_t> const test_list{ 4U, 7U, 9U, 78U };
 
    // When - Copy constructor is used to copy list,
    List<uint8_t> copy_list;
@@ -340,10 +340,10 @@ TEST_F(
    Given_ANonEmptyList_When_MoveCtorIsUsedToMoveList_Then_OriginalListIsMoved)
 {
    // Given - A non-empty string,
-   List<uint8_t> test_list{4U, 7U, 9U, 78U};
-   auto const original_list_size = test_list.size();
+   List<uint8_t> test_list{ 4U, 7U, 9U, 78U };
+   auto const original_list_size  = test_list.size();
    auto const original_list_front = test_list.front();
-   auto const original_list_back = test_list.back();
+   auto const original_list_back  = test_list.back();
 
    // When - Move constructor is used to move list,
    List<uint8_t> move_list(std::move(test_list));
@@ -363,10 +363,10 @@ TEST_F(
    Given_ANonEmptyList_When_MoveAssignmentIsUsedToMoveList_Then_OriginalListIsMoved)
 {
    // Given - A non-empty string,
-   List<uint8_t> test_list{4U, 7U, 9U, 78U};
-   auto const original_list_size = test_list.size();
+   List<uint8_t> test_list{ 4U, 7U, 9U, 78U };
+   auto const original_list_size  = test_list.size();
    auto const original_list_front = test_list.front();
-   auto const original_list_back = test_list.back();
+   auto const original_list_back  = test_list.back();
 
    // When - Move assignment is used to move list,
    List<uint8_t> move_list;

--- a/tests/unit/list/list_tests.cpp
+++ b/tests/unit/list/list_tests.cpp
@@ -2,17 +2,15 @@
 // Copyright (c) 2024 Prashant Gandhi - All rights are reserved
 ////////////////////////////////////////////////////////////////////////////////////////////////////
 
-
 ////////////////////////////////////////////////////////////////////////////////////////////////////
 // Include(s)
 ////////////////////////////////////////////////////////////////////////////////////////////////////
-#include "gtest/gtest.h"
-#include "gmock/gmock.h"
-
-#include "milky_way/list/list.h"
-
 #include <cstdint>
 #include <string>
+
+#include "gmock/gmock.h"
+#include "gtest/gtest.h"
+#include "milky_way/list/list.h"
 
 ////////////////////////////////////////////////////////////////////////////////////////////////////
 // Namespace(s)
@@ -43,7 +41,8 @@ class ListTest : public testing::Test
 ////////////////////////////////////////////////////////////////////////////////////////////////////
 
 ////////////////////////////////////////////////////////////////////////////////////////////////////
-TEST_F(ListTest, Given_AListObjWithNoElement_When_IsEmptyIsCalled_Then_TrueIsReturned)
+TEST_F(ListTest,
+       Given_AListObjWithNoElement_When_IsEmptyIsCalled_Then_TrueIsReturned)
 {
    // Given - A List object with no element,
    List<uint32_t> test_list{};
@@ -54,10 +53,11 @@ TEST_F(ListTest, Given_AListObjWithNoElement_When_IsEmptyIsCalled_Then_TrueIsRet
 }
 
 ////////////////////////////////////////////////////////////////////////////////////////////////////
-TEST_F(ListTest, Given_AListObjWithElements_When_IsEmptyIsCalled_Then_FalseIsReturned)
+TEST_F(ListTest,
+       Given_AListObjWithElements_When_IsEmptyIsCalled_Then_FalseIsReturned)
 {
    // Given - A List object with no element,
-   List<uint32_t> test_list{ 1U, 2U, 3U };
+   List<uint32_t> test_list{1U, 2U, 3U};
 
    // When - is_empty() is called,
    // Then - False is returned
@@ -65,7 +65,8 @@ TEST_F(ListTest, Given_AListObjWithElements_When_IsEmptyIsCalled_Then_FalseIsRet
 }
 
 ////////////////////////////////////////////////////////////////////////////////////////////////////
-TEST_F(ListTest, Given_AListObjWithNoElement_When_SizeIsCalled_Then_ZeroIsReturned)
+TEST_F(ListTest,
+       Given_AListObjWithNoElement_When_SizeIsCalled_Then_ZeroIsReturned)
 {
    // Given - A List object with no element,
    List<std::string> test_list{};
@@ -76,10 +77,12 @@ TEST_F(ListTest, Given_AListObjWithNoElement_When_SizeIsCalled_Then_ZeroIsReturn
 }
 
 ////////////////////////////////////////////////////////////////////////////////////////////////////
-TEST_F(ListTest, Given_AListObjWithElements_When_SizeIsCalled_Then_ExpectedSizeIsReturned)
+TEST_F(ListTest,
+       Given_AListObjWithElements_When_SizeIsCalled_Then_ExpectedSizeIsReturned)
 {
    // Given - A List object with no element,
-   List<std::string> test_list{ std::string("First"), std::string("Sec"), std::string("Third") };
+   List<std::string> test_list{std::string("First"), std::string("Sec"),
+                               std::string("Third")};
 
    // When - size() is called,
    // Then - Expected size is returned
@@ -87,14 +90,16 @@ TEST_F(ListTest, Given_AListObjWithElements_When_SizeIsCalled_Then_ExpectedSizeI
 }
 
 ////////////////////////////////////////////////////////////////////////////////////////////////////
-TEST_F(ListTest, Given_AListObj_When_AnElementIsPushedAtBack_Then_AnElementIsAddedAtCorrectLocation)
+TEST_F(
+   ListTest,
+   Given_AListObj_When_AnElementIsPushedAtBack_Then_AnElementIsAddedAtCorrectLocation)
 {
    // Given - A List,
-   List<int32_t> test_list{ 78, 98, 547 };
+   List<int32_t> test_list{78, 98, 547};
 
    // When - An element is pushed at back,
-   int const new_element{ 70 };
-   test_list.push_back( new_element );
+   int const new_element{70};
+   test_list.push_back(new_element);
    auto const back_element = test_list.back();
 
    // Then - An Element is added at correct location.
@@ -104,14 +109,16 @@ TEST_F(ListTest, Given_AListObj_When_AnElementIsPushedAtBack_Then_AnElementIsAdd
 }
 
 ////////////////////////////////////////////////////////////////////////////////////////////////////
-TEST_F(ListTest, Given_AListObj_When_AnElementIsPushedAtBeginning_Then_AnElementIsAddedAtCorrectLocation)
+TEST_F(
+   ListTest,
+   Given_AListObj_When_AnElementIsPushedAtBeginning_Then_AnElementIsAddedAtCorrectLocation)
 {
    // Given - A List,
-   List<int32_t> test_list{ 78, 98, 547 };
+   List<int32_t> test_list{78, 98, 547};
 
    // When - An element is pushed at the beginning,
-   int const new_element{ 70 };
-   test_list.push_front( new_element );
+   int const new_element{70};
+   test_list.push_front(new_element);
    auto const back_element = test_list.back();
 
    // Then - An Element is added at correct location.
@@ -121,10 +128,11 @@ TEST_F(ListTest, Given_AListObj_When_AnElementIsPushedAtBeginning_Then_AnElement
 }
 
 ////////////////////////////////////////////////////////////////////////////////////////////////////
-TEST_F(ListTest, Given_ANonEmptyList_When_ExistingElementIsSearched_Then_TrueIsReturned)
+TEST_F(ListTest,
+       Given_ANonEmptyList_When_ExistingElementIsSearched_Then_TrueIsReturned)
 {
    // Given - A non-empty List,
-   List<int32_t> test_list{ 78, 98, 547 };
+   List<int32_t> test_list{78, 98, 547};
 
    // When - An existing element is searched,
    // Then - True is returned.
@@ -132,10 +140,12 @@ TEST_F(ListTest, Given_ANonEmptyList_When_ExistingElementIsSearched_Then_TrueIsR
 }
 
 ////////////////////////////////////////////////////////////////////////////////////////////////////
-TEST_F(ListTest, Given_ANonEmptyList_When_NonExistingElementIsSearched_Then_TrueIsReturned)
+TEST_F(
+   ListTest,
+   Given_ANonEmptyList_When_NonExistingElementIsSearched_Then_TrueIsReturned)
 {
    // Given - A non-empty List,
-   List<int32_t> test_list{ 78, 98, 547 };
+   List<int32_t> test_list{78, 98, 547};
 
    // When - A non existing element is searched,
    // Then - False is returned.
@@ -143,10 +153,11 @@ TEST_F(ListTest, Given_ANonEmptyList_When_NonExistingElementIsSearched_Then_True
 }
 
 ////////////////////////////////////////////////////////////////////////////////////////////////////
-TEST_F(ListTest, Given_ANonEmptyList_When_ClearIsCalled_Then_AllElementsShouldBeRemoved)
+TEST_F(ListTest,
+       Given_ANonEmptyList_When_ClearIsCalled_Then_AllElementsShouldBeRemoved)
 {
    // Given - A non-empty List,
-   List<int32_t> test_list{ 78, 98, 547 };
+   List<int32_t> test_list{78, 98, 547};
 
    // When - clear() is called,
    test_list.clear();
@@ -157,10 +168,12 @@ TEST_F(ListTest, Given_ANonEmptyList_When_ClearIsCalled_Then_AllElementsShouldBe
 }
 
 ////////////////////////////////////////////////////////////////////////////////////////////////////
-TEST_F(ListTest, Given_ANonEmptyList_When_ExistingElementIsRemoved_Then_ElementShouldNotBePresentInList)
+TEST_F(
+   ListTest,
+   Given_ANonEmptyList_When_ExistingElementIsRemoved_Then_ElementShouldNotBePresentInList)
 {
    // Given - A non-empty List,
-   List<int32_t> test_list{ 78, 98, 547 };
+   List<int32_t> test_list{78, 98, 547};
 
    // When - An existing element is removed,
    // Then - An element should not be present in list.
@@ -175,10 +188,12 @@ TEST_F(ListTest, Given_ANonEmptyList_When_ExistingElementIsRemoved_Then_ElementS
 ////////////////////////////////////////////////////////////////////////////////////////////////////
 
 ////////////////////////////////////////////////////////////////////////////////////////////////////
-TEST_F(ListTest, Given_ANonEmptyList_When_ListObjIsComparedWithItselfUsingEqualityOperator_Then_TrueIsReturned)
+TEST_F(
+   ListTest,
+   Given_ANonEmptyList_When_ListObjIsComparedWithItselfUsingEqualityOperator_Then_TrueIsReturned)
 {
    // Given - A non-empty string,
-   List<uint8_t> const test_list{ 4U, 7U, 9U, 78U };
+   List<uint8_t> const test_list{4U, 7U, 9U, 78U};
 
    // When - List object is compared with itself using equality(==) operator,
    // Then - True is returned.
@@ -191,10 +206,11 @@ TEST_F(
    Given_TwoNonEmptyList_When_ListObjIsComparedWithAnotherListContainingSameElementsEqualityOperator_Then_TrueIsReturned)
 {
    // Given - Two non-empty string,
-   List<uint8_t> const test_list_1{ 4U, 7U, 9U, 78U };
-   List<uint8_t> const test_list_2{ 4U, 7U, 9U, 78U };
+   List<uint8_t> const test_list_1{4U, 7U, 9U, 78U};
+   List<uint8_t> const test_list_2{4U, 7U, 9U, 78U};
 
-   // When - List object is compared with another list containing same elements using equality(==)
+   // When - List object is compared with another list containing same elements
+   // using equality(==)
    //        operator,
    // Then - True is returned.
    EXPECT_TRUE(test_list_1 == test_list_2);
@@ -206,10 +222,11 @@ TEST_F(
    Given_TwoNonEmptyList_When_ListObjIsComparedWithAnotherListContainingDifferentElementsEqualityOperator_Then_FalseIsReturned)
 {
    // Given - Two non-empty string,
-   List<uint8_t> const test_list_1{ 4U, 7U, 9U, 78U };
-   List<uint8_t> const test_list_2{ 4U, 7U, 9U, 75U };
+   List<uint8_t> const test_list_1{4U, 7U, 9U, 78U};
+   List<uint8_t> const test_list_2{4U, 7U, 9U, 75U};
 
-   // When - List object is compared with another list containing different elements using
+   // When - List object is compared with another list containing different
+   // elements using
    //        equality(==) operator,
    // Then - False is returned.
    EXPECT_FALSE(test_list_1 == test_list_2);
@@ -220,10 +237,12 @@ TEST_F(
 ////////////////////////////////////////////////////////////////////////////////////////////////////
 
 ////////////////////////////////////////////////////////////////////////////////////////////////////
-TEST_F(ListTest, Given_ANonEmptyList_When_ListObjIsComparedWithItselfUsingInequalityOperator_Then_FalseIsReturned)
+TEST_F(
+   ListTest,
+   Given_ANonEmptyList_When_ListObjIsComparedWithItselfUsingInequalityOperator_Then_FalseIsReturned)
 {
    // Given - A non-empty string,
-   List<uint8_t> const test_list{ 4U, 7U, 9U, 78U };
+   List<uint8_t> const test_list{4U, 7U, 9U, 78U};
 
    // When - List object is compared with itself using inequality(!=) operator,
    // Then - False is returned.
@@ -236,10 +255,11 @@ TEST_F(
    Given_TwoNonEmptyList_When_ListObjIsComparedWithAnotherListContainingSameElementsInequalityOperator_Then_FalseIsReturned)
 {
    // Given - Two non-empty string,
-   List<uint8_t> const test_list_1{ 4U, 7U, 9U, 78U };
-   List<uint8_t> const test_list_2{ 4U, 7U, 9U, 78U };
+   List<uint8_t> const test_list_1{4U, 7U, 9U, 78U};
+   List<uint8_t> const test_list_2{4U, 7U, 9U, 78U};
 
-   // When - List object is compared with another list containing same elements using inequality(!=)
+   // When - List object is compared with another list containing same elements
+   // using inequality(!=)
    //        operator,
    // Then - False is returned.
    EXPECT_FALSE(test_list_1 != test_list_2);
@@ -251,10 +271,11 @@ TEST_F(
    Given_TwoNonEmptyList_When_ListObjIsComparedWithAnotherListContainingDifferentElementsInequalityOperator_Then_TrueIsReturned)
 {
    // Given - Two non-empty string,
-   List<uint8_t> const test_list_1{ 4U, 7U, 9U, 78U };
-   List<uint8_t> const test_list_2{ 4U, 7U, 9U, 75U };
+   List<uint8_t> const test_list_1{4U, 7U, 9U, 78U};
+   List<uint8_t> const test_list_2{4U, 7U, 9U, 75U};
 
-   // When - List object is compared with another list containing different elements using
+   // When - List object is compared with another list containing different
+   // elements using
    //        inequality(!=) operator,
    // Then - True is returned.
    EXPECT_TRUE(test_list_1 != test_list_2);
@@ -265,10 +286,12 @@ TEST_F(
 ////////////////////////////////////////////////////////////////////////////////////////////////////
 
 ////////////////////////////////////////////////////////////////////////////////////////////////////
-TEST_F(ListTest, Given_ANonEmptyList_When_CopyCtorIsUsedToCopyList_Then_CopiedListContainsSameData)
+TEST_F(
+   ListTest,
+   Given_ANonEmptyList_When_CopyCtorIsUsedToCopyList_Then_CopiedListContainsSameData)
 {
    // Given - A non-empty string,
-   List<uint8_t> const test_list{ 4U, 7U, 9U, 78U };
+   List<uint8_t> const test_list{4U, 7U, 9U, 78U};
 
    // When - Copy constructor is used to copy list,
    auto const copy_list = test_list;
@@ -276,16 +299,21 @@ TEST_F(ListTest, Given_ANonEmptyList_When_CopyCtorIsUsedToCopyList_Then_CopiedLi
    // Then - Copied list contains same elements.
    EXPECT_TRUE(copy_list == test_list);
    EXPECT_FALSE(copy_list.is_empty());
-   EXPECT_THAT((copy_list.size() == test_list.size()), "Size is not equal; Copy failed");
-   EXPECT_THAT((copy_list.front() == test_list.front()), "Front is not equal; Copy failed");
-   EXPECT_THAT((copy_list.back() == test_list.back()), "Back is not equal; Copy failed");
+   EXPECT_THAT((copy_list.size() == test_list.size()),
+               "Size is not equal; Copy failed");
+   EXPECT_THAT((copy_list.front() == test_list.front()),
+               "Front is not equal; Copy failed");
+   EXPECT_THAT((copy_list.back() == test_list.back()),
+               "Back is not equal; Copy failed");
 }
 
 ////////////////////////////////////////////////////////////////////////////////////////////////////
-TEST_F(ListTest, Given_ANonEmptyList_When_CopyAssignmentIsUsedToCopyList_Then_CopiedListContainsSameData)
+TEST_F(
+   ListTest,
+   Given_ANonEmptyList_When_CopyAssignmentIsUsedToCopyList_Then_CopiedListContainsSameData)
 {
    // Given - A non-empty string,
-   List<uint8_t> const test_list{ 4U, 7U, 9U, 78U };
+   List<uint8_t> const test_list{4U, 7U, 9U, 78U};
 
    // When - Copy constructor is used to copy list,
    List<uint8_t> copy_list;
@@ -294,9 +322,12 @@ TEST_F(ListTest, Given_ANonEmptyList_When_CopyAssignmentIsUsedToCopyList_Then_Co
    // Then - Copied list contains same elements.
    EXPECT_TRUE(copy_list == test_list);
    EXPECT_FALSE(copy_list.is_empty());
-   EXPECT_THAT((copy_list.size() == test_list.size()), "Size is not equal; Copy failed");
-   EXPECT_THAT((copy_list.front() == test_list.front()), "Front is not equal; Copy failed");
-   EXPECT_THAT((copy_list.back() == test_list.back()), "Back is not equal; Copy failed");
+   EXPECT_THAT((copy_list.size() == test_list.size()),
+               "Size is not equal; Copy failed");
+   EXPECT_THAT((copy_list.front() == test_list.front()),
+               "Front is not equal; Copy failed");
+   EXPECT_THAT((copy_list.back() == test_list.back()),
+               "Back is not equal; Copy failed");
 }
 
 ////////////////////////////////////////////////////////////////////////////////////////////////////
@@ -304,10 +335,12 @@ TEST_F(ListTest, Given_ANonEmptyList_When_CopyAssignmentIsUsedToCopyList_Then_Co
 ////////////////////////////////////////////////////////////////////////////////////////////////////
 
 ////////////////////////////////////////////////////////////////////////////////////////////////////
-TEST_F(ListTest, Given_ANonEmptyList_When_MoveCtorIsUsedToMoveList_Then_OriginalListIsMoved)
+TEST_F(
+   ListTest,
+   Given_ANonEmptyList_When_MoveCtorIsUsedToMoveList_Then_OriginalListIsMoved)
 {
    // Given - A non-empty string,
-   List<uint8_t> test_list{ 4U, 7U, 9U, 78U };
+   List<uint8_t> test_list{4U, 7U, 9U, 78U};
    auto const original_list_size = test_list.size();
    auto const original_list_front = test_list.front();
    auto const original_list_back = test_list.back();
@@ -318,15 +351,19 @@ TEST_F(ListTest, Given_ANonEmptyList_When_MoveCtorIsUsedToMoveList_Then_Original
    // Then - Original list is moved.
    EXPECT_TRUE(test_list.is_empty());
    EXPECT_THAT((move_list.size() == original_list_size), "Size mismatch");
-   EXPECT_THAT((move_list.front() == original_list_front), "Front element mismatch");
-   EXPECT_THAT((move_list.back() == original_list_back), "Back element mismatch");
+   EXPECT_THAT((move_list.front() == original_list_front),
+               "Front element mismatch");
+   EXPECT_THAT((move_list.back() == original_list_back),
+               "Back element mismatch");
 }
 
 ////////////////////////////////////////////////////////////////////////////////////////////////////
-TEST_F(ListTest, Given_ANonEmptyList_When_MoveAssignmentIsUsedToMoveList_Then_OriginalListIsMoved)
+TEST_F(
+   ListTest,
+   Given_ANonEmptyList_When_MoveAssignmentIsUsedToMoveList_Then_OriginalListIsMoved)
 {
    // Given - A non-empty string,
-   List<uint8_t> test_list{ 4U, 7U, 9U, 78U };
+   List<uint8_t> test_list{4U, 7U, 9U, 78U};
    auto const original_list_size = test_list.size();
    auto const original_list_front = test_list.front();
    auto const original_list_back = test_list.back();
@@ -338,9 +375,11 @@ TEST_F(ListTest, Given_ANonEmptyList_When_MoveAssignmentIsUsedToMoveList_Then_Or
    // Then - Original list is moved.
    EXPECT_TRUE(test_list.is_empty());
    EXPECT_THAT((move_list.size() == original_list_size), "Size mismatch");
-   EXPECT_THAT((move_list.front() == original_list_front), "Front element mismatch");
-   EXPECT_THAT((move_list.back() == original_list_back), "Back element mismatch");
+   EXPECT_THAT((move_list.front() == original_list_front),
+               "Front element mismatch");
+   EXPECT_THAT((move_list.back() == original_list_back),
+               "Back element mismatch");
 }
 
-} // namespace MilkyWay
-} // namespace Prashant
+}  // namespace MilkyWay
+}  // namespace Prashant


### PR DESCRIPTION
### Overview
Added clang-format rules.

### Details
* Integrated clang-formatter with VS Code by installing extension from "Xaver Hellauer".
* Formatted whole repo with the formatter.

For more detail on how to integrate formatter with VS Code, visit [this site](https://skillupwards.com/blog/formatting-c-cplusplus-code-using-clangformat-and-vscode)